### PR TITLE
fix: reject duplicated top-level workflow output sections

### DIFF
--- a/src/workflow-output-artifacts.ts
+++ b/src/workflow-output-artifacts.ts
@@ -470,7 +470,7 @@ function validateSectionLayout(
 	issues: WorkflowOutputIssue[],
 	requirements: SectionRequirements,
 ): void {
-	validateSectionCounts(sections, issues, requirements);
+	validateSectionCounts(raw, sections, issues, requirements);
 	validateCanonicalOrder(sections, issues, requirements);
 	validateNoOutsideText(raw, sections, issues);
 }
@@ -481,6 +481,7 @@ function parseSanitizedWorkflowOutput(
 ): ParsedWorkflowOutput | undefined {
 	const requirements = sectionRequirements(options);
 	const sections = collectSections(raw, requirements);
+	if (hasDuplicateSectionTags(raw, sections)) return undefined;
 	if (hasExactlyRequiredSections(sections, requirements)) {
 		const sanitized = sections
 			.map((section) => raw.slice(section.start, section.end).trim())
@@ -559,6 +560,7 @@ function hasExactlyRequiredSections(
 }
 
 function validateSectionCounts(
+	raw: string,
 	sections: readonly SectionMatch[],
 	issues: WorkflowOutputIssue[],
 	requirements: SectionRequirements,
@@ -568,7 +570,8 @@ function validateSectionCounts(
 		const required = sectionRequired(name, requirements);
 		const count = counts.get(name) ?? 0;
 		if (required && count === 0) issues.push(missingSectionIssue(name));
-		if (count > 1) issues.push(duplicateSectionIssue(name));
+		const tagCount = sectionOpenTagCount(raw, name, sections);
+		if (tagCount > 1) issues.push(duplicateSectionIssue(name, tagCount));
 	}
 }
 
@@ -2079,6 +2082,43 @@ function sectionCounts(
 	return counts;
 }
 
+function hasDuplicateSectionTags(
+	raw: string,
+	sections: readonly SectionMatch[],
+): boolean {
+	return CANONICAL_SECTION_ORDER.some(
+		(name) => sectionOpenTagCount(raw, name, sections) > 1,
+	);
+}
+
+function sectionOpenTagCount(
+	raw: string,
+	section: WorkflowOutputSectionName,
+	sections: readonly SectionMatch[],
+): number {
+	// Opening tags inside a matched section span are literal content (for
+	// example protocol text quoted in control JSON strings); only tags outside
+	// every matched span count toward the exactly-once layout rule.
+	const tag = `<${section}>`;
+	let count = 0;
+	let cursor = 0;
+	while (true) {
+		const index = raw.indexOf(tag, cursor);
+		if (index < 0) return count;
+		if (!insideMatchedSection(index, sections)) count += 1;
+		cursor = index + tag.length;
+	}
+}
+
+function insideMatchedSection(
+	index: number,
+	sections: readonly SectionMatch[],
+): boolean {
+	return sections.some(
+		(section) => index > section.start && index < section.end,
+	);
+}
+
 function sectionRequired(
 	name: WorkflowOutputSectionName,
 	requirements: SectionRequirements,
@@ -2108,11 +2148,12 @@ function missingSectionIssue(
 
 function duplicateSectionIssue(
 	section: WorkflowOutputSectionName,
+	count: number,
 ): WorkflowOutputIssue {
 	return {
 		code: "duplicate_section",
 		section,
-		message: `${section} section must appear exactly once`,
+		message: `${section} section must appear exactly once; found ${count}`,
 	};
 }
 

--- a/test/unit/output-duplicate-section-rejection.test.mjs
+++ b/test/unit/output-duplicate-section-rejection.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+	parseWorkflowOutput,
+	parseWorkflowOutputForBundle,
+} from "../../.tmp/unit/workflow-output-artifacts.js";
+
+const VALID_OUTPUT = [
+	'<control>{"schema":"stage-control-v1","digest":"first"}</control>',
+	"<analysis>valid analysis</analysis>",
+	"<refs>[]</refs>",
+].join("\n");
+
+const DUPLICATED_CONTROL_OUTPUT = [
+	VALID_OUTPUT,
+	'<control>{"schema":"stage-control-v1","digest":"second"}</control>',
+].join("\n");
+
+test("parseWorkflowOutput rejects repeated control sections with duplicate_section", () => {
+	const parsed = parseWorkflowOutput(DUPLICATED_CONTROL_OUTPUT);
+	assert.equal(parsed.valid, false);
+	const duplicate = parsed.issues.find(
+		(issue) => issue.code === "duplicate_section",
+	);
+	assert.ok(duplicate, "expected a duplicate_section issue");
+	assert.equal(duplicate.section, "control");
+	assert.match(duplicate.message, /exactly once; found 2/);
+});
+
+test("parseWorkflowOutputForBundle must not sanitize away a repeated section", () => {
+	const parsed = parseWorkflowOutputForBundle(DUPLICATED_CONTROL_OUTPUT);
+	assert.equal(parsed.valid, false);
+	assert.ok(
+		parsed.issues.some((issue) => issue.code === "duplicate_section"),
+		"sanitized recovery must not erase the duplicate_section evidence",
+	);
+});
+
+test("parseWorkflowOutput rejects a repeated analysis section with duplicate_section", () => {
+	const parsed = parseWorkflowOutput(
+		`${VALID_OUTPUT}\n<analysis>second analysis</analysis>`,
+	);
+	assert.equal(parsed.valid, false);
+	assert.ok(
+		parsed.issues.some(
+			(issue) =>
+				issue.code === "duplicate_section" && issue.section === "analysis",
+		),
+	);
+});
+
+test("parseWorkflowOutput still rejects a trailing repeated refs section", () => {
+	// The trailing block is absorbed into the refs span (last section has no
+	// next-tag anchor), so rejection comes from refs JSON validation rather
+	// than duplicate_section; either way the output must not be valid.
+	const parsed = parseWorkflowOutput(`${VALID_OUTPUT}\n<refs>[]</refs>`);
+	assert.equal(parsed.valid, false);
+});
+
+test("literal opening tags inside section content stay tolerated", () => {
+	const raw = [
+		"<control>",
+		JSON.stringify({
+			schema: "stage-control-v1",
+			digest: "quoted protocol",
+			evidence:
+				"Return <control>{}</control> <analysis>...</analysis> <refs>[]</refs> exactly.",
+		}),
+		"</control>",
+		"<analysis>",
+		"Analysis may mention <analysis> as literal text.",
+		"</analysis>",
+		"<refs>",
+		"[]",
+		"</refs>",
+	].join("\n");
+	const parsed = parseWorkflowOutput(raw);
+	assert.equal(parsed.valid, true, JSON.stringify(parsed.issues));
+});
+
+test("parseWorkflowOutput keeps accepting exactly one section of each kind", () => {
+	const parsed = parseWorkflowOutput(VALID_OUTPUT);
+	assert.equal(parsed.valid, true);
+	assert.deepEqual(parsed.issues, []);
+});


### PR DESCRIPTION
## Problem

`docs/usage.md` states that artifact-graph task output is parsed strictly as exactly one `<control>`, followed by one `<analysis>`, followed by one `<refs>`, with no outside prose. In `@agwab/pi-workflow@0.9.0`, repeated section tags can evade that contract: `collectSections` records at most one match for each expected section, so `validateSectionCounts` never observes a count above one, and the sanitized-output fallback can discard a repeated trailing section before re-parsing.

A qualification run demonstrated the effect: an output with two complete `<control>` blocks was accepted with `outputValidation.valid=true`, no output retries, and a completed run (`workflow_mrwrw4lv_5f2c2d`). By comparison, an invalid control JSON type followed the normal invalid-output retry path and ended as `workflow_output_invalid_exhausted`.

## Reproduction

Use an otherwise valid protocol response and append a second section:

```text
<control>{"schema":"stage-control-v1","digest":"first"}</control>
<analysis>valid analysis</analysis>
<refs>[]</refs>
<control>{"schema":"stage-control-v1","digest":"second"}</control>
```

Before this change, `parseWorkflowOutputForBundle` sanitizes the first three sections and returns valid output.

## Fix

During layout validation, count canonical opening tags that appear **outside every matched section span**. When a tag is observed more than once, emit the existing `duplicate_section` validation issue with the section name and observed count, which routes the output into the existing invalid-output retry/rejection path. Sanitized-output recovery is also stopped when any canonical tag is duplicated, so recovery cannot erase the evidence before validation.

Counting only outside matched spans preserves the documented tolerance for literal tags inside section content: protocol text quoted inside control JSON strings (covered by the existing test "workflow output parser tolerates literal closing tags inside JSON strings") is still accepted, because those occurrences sit inside the matched `<control>` span.

## Tests

`test/unit/output-duplicate-section-rejection.test.mjs` adds regression coverage:

- repeated `<control>` block → `duplicate_section`, output invalid (both `parseWorkflowOutput` and `parseWorkflowOutputForBundle`);
- repeated `<analysis>` block → `duplicate_section`;
- trailing repeated `<refs>` block → still rejected (absorbed into the refs span and fails refs JSON validation);
- exactly-one output of each kind → unchanged, zero issues;
- literal opening tags inside section content → still tolerated.

`npm run validate` passes (713/713 unit tests, typecheck, script and public-surface checks).

## Compatibility

Valid outputs containing exactly one required section of each kind are unchanged. Outputs that repeat `<control>`, `<analysis>`, or `<refs>` at the top level now correctly enter the existing invalid-output retry/rejection path, matching the documented strict protocol.
