### PR TITLE
feat: add governed dynamic host operations

### DIFF
--- a/docs/superpowers/plans/2026-08-07-governed-host-operations.md
+++ b/docs/superpowers/plans/2026-08-07-governed-host-operations.md
@@ -1,0 +1,74 @@
+# Governed Host Operations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a trusted host provide explicitly declared, JSON-only dynamic-controller operations with durable replay and crash reconciliation.
+
+**Architecture:** Workflow specs declare operation aliases mapped to host capability names. Dynamic-controller workers send only an alias and JSON request; the parent engine resolves the registered adapter, supplies frozen run and bundle provenance, and records started/completed events. Completed calls replay from the ledger, while an interrupted started call uses the adapter's reconciliation method with the same idempotency key.
+
+**Tech Stack:** TypeScript, Node worker threads, JSONL dynamic events, Node test runner.
+
+## Global Constraints
+
+- Never serialize host adapter functions into worker data.
+- Reject undeclared aliases, missing capabilities, and non-JSON requests or results before completion.
+- Persist a stable request hash and idempotency key before invoking the adapter.
+- Never invoke an adapter again after a matching completed event.
+- A dangling started event may call only the adapter reconciliation method.
+- Keep product-specific workflow, path, source-SHA, and result policy outside this package.
+
+---
+
+### Task 1: Schema and compiled contract
+
+**Files:**
+- Modify: `src/types.ts`
+- Modify: `src/artifact-graph-schema.ts`
+- Modify: `src/compiler.ts`
+- Test: `test/unit/unit-dynamic-runtime.test.mjs`
+
+**Interfaces:**
+- Consumes: `dynamic.hostOperations` as `{ [alias]: { capability: string } }`.
+- Produces: `CompiledDynamicWorkflowTask.hostOperations` with the same immutable alias-to-capability mapping.
+
+- [ ] Add failing parser/compiler tests for a valid declaration, unknown fields, reserved aliases, and missing capability.
+- [ ] Run the focused test and confirm the new cases fail because `hostOperations` is unsupported.
+- [ ] Add the minimal types, validation, and compiler projection.
+- [ ] Re-run the focused test and confirm it passes.
+
+### Task 2: Durable parent-owned invocation
+
+**Files:**
+- Create: `src/dynamic-host-operations.ts`
+- Modify: `src/dynamic-events.ts`
+- Modify: `src/dynamic-state.ts`
+- Modify: `src/engine.ts`
+- Test: `test/unit/dynamic-host-operations.test.mjs`
+- Modify: `test/unit/unit-test-support.mjs`
+
+**Interfaces:**
+- Consumes: `WorkflowHostCapabilities`, where each capability supplies `invoke(request, context)` and `reconcile(request, context)`.
+- Produces: worker API `ctx.host.invoke(alias, request)` and dynamic events `host.started` / `host.completed`.
+
+- [ ] Add failing tests proving declared invocation, frozen provenance, missing/undeclared rejection, JSON validation, and no adapter functions in worker data.
+- [ ] Add failing replay tests proving completed calls are returned without reinvocation and dangling starts call reconciliation with the original idempotency key.
+- [ ] Run the focused tests and confirm the expected missing-API failures.
+- [ ] Implement the host operation runner, engine option threading, worker op, event persistence, and replay-prefix integration.
+- [ ] Re-run the focused tests and confirm they pass.
+
+### Task 3: Public contract and verification
+
+**Files:**
+- Modify: `src/index.ts`
+- Modify: `docs/usage.md`
+- Test: `test/unit/wb-012-public-contracts.test.mjs`
+- Test: `test/unit/dynamic-host-operations.test.mjs`
+
+**Interfaces:**
+- Consumes: the types and runtime behavior from Tasks 1 and 2.
+- Produces: documented public host capability types and scheduling options.
+
+- [ ] Add a failing public-surface assertion for the exported host capability types.
+- [ ] Export and document the API, including the requirement to pass the registry again when resuming or waiting.
+- [ ] Run focused tests, typecheck, and the package validation command.
+- [ ] Commit, push `codex/governed-host-operations`, and open a PR against `calltelemetry/pi-workflow`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -381,7 +381,10 @@ Dynamic workflows keep JSON as the source of truth while allowing trusted bundle
     "uses": "./helpers/controller.mjs",
     "mode": "graph-splice",
     "permissions": { "approval": "auto" },
-    "budget": { "maxAgents": 1000, "maxConcurrency": 16 }
+    "budget": { "maxAgents": 1000, "maxConcurrency": 16 },
+    "hostOperations": {
+      "deliver": { "capability": "example.governed-delivery.v1" }
+    }
   }
 }
 ```
@@ -391,10 +394,11 @@ Controller/helper/nested workflow refs must be bundle-local `./...` paths. Neste
 Controller context rules:
 
 - Generated agents are real workflow tasks: `ctx.agent({ id, agent, prompt, tools })` inserts a deterministic `stageId.id` task into `compiled.json` and `run.json`, persists a request hash in `dynamic/events.jsonl`, and replays fail-closed if the same id later changes request shape.
-- On resume, controllers must re-issue previously recorded `ctx.agent`, `ctx.helper`, and `ctx.workflow` operations in the same order before issuing new operations; omitted or out-of-order replay fails closed with an explicit replay-invariant error.
+- On resume, controllers must re-issue previously recorded `ctx.agent`, `ctx.helper`, `ctx.workflow`, and `ctx.host.invoke` operations in the same order before issuing new operations; omitted or out-of-order replay fails closed with an explicit replay-invariant error.
 - Use `ctx.parallel([() => ctx.agent(...), ...])` for dynamic fan-out; the runtime records queued sibling generation ops before the controller suspends, and non-suspension operation failures make the controller fail closed. Generated dependency cycles are rejected.
 - `ctx.helper(name, input)` can call only helpers declared in `dynamic.helpers`; pure/retry-safe helpers may set `idempotent: true` so a crash after `helper.started` but before `helper.completed` can retry the helper instead of permanently failing closed.
 - `ctx.workflow(name, input)` can call only nested specs declared in `dynamic.workflows`.
+- `ctx.host.invoke(alias, request)` sends JSON to a parent-process adapter for an alias declared in `dynamic.hostOperations`. Hosts register explicit capability providers with `registerWorkflowHostCapabilityProvider`; missing capabilities fail closed. The engine persists `host.started` before invocation and `host.completed` after a JSON result. Resume replays completed results without another side effect and sends a dangling start only to the adapter's required `reconcile` method with the original idempotency key. Adapter functions never cross the worker boundary.
 
 Dynamic outputs should be compact typed artifacts. The controller returns normal workflow sections through `{ control, analysis, refs }`; generated child agents must return the same `<control>`, `<analysis>`, `<refs>` protocol as other artifact-graph tasks. When a controller result includes `outputTasks`/`outputTaskIds` (the built-in decision loop sets this from accepted `synthesize` actions), downstream `from: "<dynamic-stage>"` reducers also receive those exported task artifacts as stable sources such as `<dynamic-stage>.output`. Runtime state is stored under `.pi/workflows/<run-id>/dynamic/`:
 

--- a/src/artifact-graph-schema.ts
+++ b/src/artifact-graph-schema.ts
@@ -146,6 +146,7 @@ const DYNAMIC_KEYS = new Set([
 	"permissions",
 	"helpers",
 	"workflows",
+	"hostOperations",
 	"decisionLoop",
 ]);
 const DYNAMIC_BUDGET_KEYS = new Set([
@@ -168,6 +169,7 @@ const DYNAMIC_HELPER_KEYS = new Set([
 	"idempotent",
 ]);
 const DYNAMIC_NESTED_WORKFLOW_KEYS = new Set(["uses"]);
+const DYNAMIC_HOST_OPERATION_KEYS = new Set(["capability"]);
 const DYNAMIC_DECISION_LOOP_KEYS = new Set([
 	"planner",
 	"workerDefaults",
@@ -1529,6 +1531,11 @@ function validateDynamicStage(
 		`${path}.dynamic.workflows`,
 		issues,
 	);
+	validateDynamicHostOperations(
+		dynamic.hostOperations,
+		`${path}.dynamic.hostOperations`,
+		issues,
+	);
 	validateDynamicDecisionLoop(
 		dynamic.decisionLoop,
 		`${path}.dynamic.decisionLoop`,
@@ -1682,6 +1689,53 @@ function validateDynamicWorkflows(
 					message: "must reference a workflow .json spec",
 				});
 			}
+		}
+	}
+}
+
+function validateDynamicHostOperations(
+	value: unknown,
+	path: string,
+	issues: ValidationIssue[],
+): void {
+	if (value === undefined) return;
+	const operations = recordAt(value, path, issues);
+	if (!operations) return;
+	for (const [key, operationValue] of Object.entries(operations)) {
+		if (!STAGE_ID_PATTERN.test(key)) {
+			issues.push({
+				path: `${path}.${jsonKey(key)}`,
+				message: "host operation alias must contain only letters, numbers, _ and -",
+			});
+		}
+		if (RESERVED_DYNAMIC_MAP_KEYS.has(key)) {
+			issues.push({
+				path: `${path}.${jsonKey(key)}`,
+				message: "host operation alias is reserved",
+			});
+		}
+		const operationPath = `${path}.${jsonKey(key)}`;
+		const operation = recordAt(operationValue, operationPath, issues);
+		if (!operation) continue;
+		rejectUnknownKeys(
+			operation,
+			DYNAMIC_HOST_OPERATION_KEYS,
+			operationPath,
+			issues,
+		);
+		const capability = requiredString(
+			operation.capability,
+			`${operationPath}.capability`,
+			issues,
+		);
+		if (
+			capability !== undefined &&
+			!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(capability)
+		) {
+			issues.push({
+				path: `${operationPath}.capability`,
+				message: "must be a path-free capability identifier of at most 128 characters",
+			});
 		}
 	}
 }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -2146,6 +2146,15 @@ function buildDynamicTask(
 			usesPath: resolve(specDir, String(workflow.uses)),
 		};
 	}
+	const hostOperations: Record<string, any> = {};
+	for (const [operationId, operation] of Object.entries(
+		isPlainRecord(dynamic.hostOperations) ? dynamic.hostOperations : {},
+	)) {
+		if (!isPlainRecord(operation)) continue;
+		hostOperations[operationId] = {
+			capability: String(operation.capability),
+		};
+	}
 	const decisionLoop = compileDynamicDecisionLoop(
 		dynamic.decisionLoop,
 		runtimePriority,
@@ -2211,6 +2220,7 @@ function buildDynamicTask(
 			},
 			helpers,
 			workflows,
+			hostOperations,
 			...(decisionLoop ? { decisionLoop } : {}),
 			...(runtimePriority.runtimeOverrides
 				? { runtimeOverrides: runtimePriority.runtimeOverrides }

--- a/src/dynamic-controller-policy.ts
+++ b/src/dynamic-controller-policy.ts
@@ -205,6 +205,14 @@ async function dynamicApprovalRequestPayload(input: {
 				{ uses: workflow.uses },
 			]),
 		),
+		hostOperations: Object.fromEntries(
+			Object.entries(input.dynamic.hostOperations ?? {})
+				.sort(([left], [right]) => left.localeCompare(right))
+				.map(([alias, operation]) => [
+					alias,
+					{ capability: operation.capability },
+				]),
+		),
 	};
 }
 
@@ -268,6 +276,9 @@ async function dynamicApprovalPromptMessage(
 	const workflows = Object.entries(input.dynamic.workflows).map(
 		([id, workflow]) => `${id} -> ${workflow.uses}`,
 	);
+	const hostOperations = Object.entries(input.dynamic.hostOperations ?? {})
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([alias, operation]) => `${alias} -> ${operation.capability}`);
 	const taskFingerprint = dynamicApprovalTaskFingerprint(input.taskText);
 	const resolvedBundleSpec = await workflowBundleSpecPath(
 		input.cwd,
@@ -301,6 +312,9 @@ async function dynamicApprovalPromptMessage(
 		workflows.length > 0
 			? `Declared nested workflows: ${workflows.join(", ")}`
 			: "Declared nested workflows: none",
+		hostOperations.length > 0
+			? `Declared host operations: ${hostOperations.join(", ")}`
+			: "Declared host operations: none",
 		"Approve only if this workflow bundle and its helper code are trusted.",
 	].join("\n");
 }

--- a/src/dynamic-events.ts
+++ b/src/dynamic-events.ts
@@ -12,6 +12,8 @@ export type DynamicWorkflowEventType =
 	| "controller.phase"
 	| "helper.started"
 	| "helper.completed"
+	| "host.started"
+	| "host.completed"
 	| "workflow.started"
 	| "workflow.completed"
 	| "fanout.planned"
@@ -241,6 +243,8 @@ function isDynamicWorkflowEventType(
 		value === "controller.phase" ||
 		value === "helper.started" ||
 		value === "helper.completed" ||
+		value === "host.started" ||
+		value === "host.completed" ||
 		value === "workflow.started" ||
 		value === "workflow.completed" ||
 		value === "fanout.planned" ||

--- a/src/dynamic-host-operations.ts
+++ b/src/dynamic-host-operations.ts
@@ -1,0 +1,175 @@
+import {
+	appendDynamicEvent,
+	hashDynamicRequest,
+	readDynamicEvents,
+} from "./dynamic-events.js";
+import {
+	deepFreeze,
+	type WorkflowHostCapabilities,
+	type WorkflowHostOperationContext,
+} from "./host-capabilities.js";
+import type {
+	CompiledDynamicWorkflowTask,
+	WorkflowRunRecord,
+	WorkflowTaskRunRecord,
+} from "./types.js";
+import {
+	workflowBundleFingerprint,
+	workflowBundleSpecPath,
+} from "./workflow-source-context-runtime.js";
+
+export async function runDynamicHostOperation(input: {
+	cwd: string;
+	run: WorkflowRunRecord;
+	controllerTask: WorkflowTaskRunRecord;
+	dynamic: CompiledDynamicWorkflowTask;
+	hostCapabilities?: WorkflowHostCapabilities;
+	alias: string;
+	callIndex: number;
+	request: unknown;
+}): Promise<unknown> {
+	const declaration = input.dynamic.hostOperations[input.alias];
+	if (!declaration)
+		throw new Error(`host operation "${input.alias}" is not declared`);
+	const adapter = input.hostCapabilities?.[declaration.capability];
+	if (!adapter)
+		throw new Error(
+			`host capability "${declaration.capability}" is unavailable`,
+		);
+	const request = strictJson(input.request, "host operation request");
+	const operationRequest = {
+		alias: input.alias,
+		capability: declaration.capability,
+		input: request,
+	};
+	const requestHash = hashDynamicRequest(operationRequest);
+	const opId = `${input.controllerTask.specId}:host:${input.alias}:${String(input.callIndex).padStart(3, "0")}`;
+	const idempotencyKey = hashDynamicRequest({
+		runId: input.run.runId,
+		controllerSpecId: input.controllerTask.specId,
+		opId,
+		requestHash,
+	});
+	const events = (await readDynamicEvents(input.cwd, input.run.runId)).filter(
+		(event) =>
+			event.controllerSpecId === input.controllerTask.specId &&
+			event.opId === opId &&
+			(event.type === "host.started" || event.type === "host.completed"),
+	);
+	const divergent = events.find((event) => event.requestHash !== requestHash);
+	if (divergent)
+		throw new Error(
+			`host operation request changed for ${opId}; previous hash ${divergent.requestHash}, new hash ${requestHash}`,
+		);
+	const completed = [...events]
+		.reverse()
+		.find((event) => event.type === "host.completed");
+	if (completed)
+		return strictJson(
+			completed.payload.result,
+			"persisted host operation result",
+		);
+
+	const bundleSpecPath = await workflowBundleSpecPath(input.cwd, input.run, {
+		required: true,
+	});
+	const bundleHash = hashDynamicRequest(
+		await workflowBundleFingerprint(input.cwd, input.run),
+	);
+	const context = deepFreeze<WorkflowHostOperationContext>({
+		cwd: input.cwd,
+		runId: input.run.runId,
+		parentRunId: input.run.parentRunId ?? null,
+		controllerSpecId: input.controllerTask.specId,
+		controllerTaskId: input.controllerTask.taskId,
+		controllerStageId:
+			input.controllerTask.stageId ??
+			input.controllerTask.specId.replace(/\.controller$/u, ""),
+		workflow: {
+			name: input.run.name ?? null,
+			specPath: input.run.specPath,
+			bundleSpecPath,
+			bundleHash,
+		},
+		operation: {
+			alias: input.alias,
+			capability: declaration.capability,
+			callIndex: input.callIndex,
+			opId,
+			requestHash,
+			idempotencyKey,
+		},
+	});
+	if (!events.some((event) => event.type === "host.started")) {
+		await appendDynamicEvent(input.cwd, input.run.runId, {
+			controllerSpecId: input.controllerTask.specId,
+			type: "host.started",
+			opId,
+			requestHash,
+			payload: {
+				alias: input.alias,
+				capability: declaration.capability,
+				idempotencyKey,
+			},
+		});
+	}
+	const result = strictJson(
+		await (events.some((event) => event.type === "host.started")
+			? adapter.reconcile(request, context)
+			: adapter.invoke(request, context)),
+		"host operation result",
+	);
+	await appendDynamicEvent(input.cwd, input.run.runId, {
+		controllerSpecId: input.controllerTask.specId,
+		type: "host.completed",
+		opId,
+		requestHash,
+		payload: {
+			alias: input.alias,
+			capability: declaration.capability,
+			idempotencyKey,
+			result,
+		},
+	});
+	return result;
+}
+
+function strictJson(value: unknown, label: string): unknown {
+	assertJsonValue(value, label, new Set());
+	let text: string;
+	try {
+		text = JSON.stringify(value);
+	} catch (error) {
+		throw new Error(
+			`${label} must be JSON serializable: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	if (text === undefined) throw new Error(`${label} must be JSON serializable`);
+	return JSON.parse(text);
+}
+
+function assertJsonValue(value: unknown, label: string, seen: Set<object>): void {
+	if (
+		value === null ||
+		typeof value === "string" ||
+		typeof value === "boolean"
+	)
+		return;
+	if (typeof value === "number" && Number.isFinite(value)) return;
+	if (typeof value !== "object")
+		throw new Error(`${label} must contain only JSON values`);
+	if (seen.has(value)) throw new Error(`${label} must not contain cycles`);
+	seen.add(value);
+	if (Array.isArray(value)) {
+		for (const item of value) assertJsonValue(item, label, seen);
+	} else {
+		const prototype = Object.getPrototypeOf(value);
+		if (prototype !== Object.prototype && prototype !== null) {
+			throw new Error(`${label} must contain only JSON objects and arrays`);
+		}
+		for (const item of Object.values(value as Record<string, unknown>)) {
+			assertJsonValue(item, label, seen);
+		}
+	}
+	seen.delete(value);
+}

--- a/src/dynamic-host-operations.ts
+++ b/src/dynamic-host-operations.ts
@@ -100,7 +100,8 @@ export async function runDynamicHostOperation(input: {
 			idempotencyKey,
 		},
 	});
-	if (!events.some((event) => event.type === "host.started")) {
+	const isDanglingStart = events.some((event) => event.type === "host.started");
+	if (!isDanglingStart) {
 		await appendDynamicEvent(input.cwd, input.run.runId, {
 			controllerSpecId: input.controllerTask.specId,
 			type: "host.started",
@@ -114,7 +115,7 @@ export async function runDynamicHostOperation(input: {
 		});
 	}
 	const result = strictJson(
-		await (events.some((event) => event.type === "host.started")
+		await (isDanglingStart
 			? adapter.reconcile(request, context)
 			: adapter.invoke(request, context)),
 		"host operation result",

--- a/src/dynamic-state.ts
+++ b/src/dynamic-state.ts
@@ -218,6 +218,7 @@ export async function ensureDynamicControllerInitialized(
 	const workflowRefs = Object.values(input.dynamic.workflows).map(
 		(workflow) => workflow.uses,
 	);
+	const hostOperations = input.dynamic.hostOperations;
 	const request = {
 		controllerSpecId: input.controllerSpecId,
 		controllerTaskId: input.controllerTaskId,
@@ -229,6 +230,7 @@ export async function ensureDynamicControllerInitialized(
 		decisionLoop: input.dynamic.decisionLoop,
 		helperRefs,
 		workflowRefs,
+		hostOperations,
 		contentFingerprint: input.contentFingerprint,
 	};
 	const requestHash = hashDynamicRequest(request);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2541,7 +2541,18 @@ export async function scheduleRun(
 				`unsupported compiled workflow type: ${compiledFlow.type}`,
 			);
 		}
-		await scheduleDag(cwd, run, compiledFlow, options, leaseSignal);
+		const scheduleOptions =
+			options.hostCapabilities !== undefined
+				? options
+				: {
+						...options,
+						hostCapabilities: await resolveWorkflowHostCapabilities({
+							cwd,
+							workflow: run.specPath,
+							task: compiledFlow.task,
+						}),
+					};
+		await scheduleDag(cwd, run, compiledFlow, scheduleOptions, leaseSignal);
 		assertScheduleLeaseActive(leaseSignal);
 
 		run = await readRunRecord(cwd, run.runId);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -74,6 +74,11 @@ import {
 	hashDynamicRequest,
 	readDynamicEvents,
 } from "./dynamic-events.js";
+import { runDynamicHostOperation } from "./dynamic-host-operations.js";
+import {
+	resolveWorkflowHostCapabilities,
+	type WorkflowHostCapabilities,
+} from "./host-capabilities.js";
 import {
 	ensureDynamicControllerInitialized,
 	readOrRebuildDynamicState,
@@ -321,11 +326,14 @@ export interface WorkflowRunOptions {
 	 * recorded on the run record. Unknown names fail closed.
 	 */
 	executionProfile?: string;
+	/** Parent-process capability adapters available to declared dynamic host operations. */
+	hostCapabilities?: WorkflowHostCapabilities;
 }
 
 interface WorkflowScheduleOptions {
 	dynamicUi?: DynamicWorkflowUi;
 	availableModels?: WorkflowModelInfo[];
+	hostCapabilities?: WorkflowHostCapabilities;
 }
 
 interface WorkflowWaitOptions extends WorkflowScheduleOptions {
@@ -351,11 +359,18 @@ export async function runWorkflowSpec(
 	options: WorkflowRunDiagnosticOptions = {},
 ): Promise<WorkflowRunRecord> {
 	const loaded = await loadWorkflowSpec(specPath, cwd);
+	const hostCapabilities =
+		options.hostCapabilities ??
+		(await resolveWorkflowHostCapabilities({
+			cwd,
+			workflow: loaded.specPath,
+			task: options.task,
+		}));
 	return runLoadedWorkflowSpec(
 		cwd,
 		loaded.specPath,
 		loaded.spec,
-		options,
+		{ ...options, hostCapabilities },
 		"named-workflow",
 	);
 }
@@ -476,6 +491,7 @@ async function runLoadedWorkflowSpec(
 	const scheduleOptions = {
 		dynamicUi: options.dynamicUi,
 		availableModels: options.availableModels,
+		hostCapabilities: options.hostCapabilities,
 	};
 	const scheduled =
 		(await scheduleRun(cwd, initialized.runId, compiled, scheduleOptions)) ??
@@ -5194,6 +5210,7 @@ async function executeDynamicControllerTask(
 			dynamic: compiledTask.dynamic,
 			dynamicUi: options.dynamicUi,
 			availableModels: options.availableModels,
+			hostCapabilities: options.hostCapabilities,
 			stopSignal: stop.signal,
 		});
 		await throwIfWorkflowStopRequested(cwd, run.runId);
@@ -5384,6 +5401,7 @@ async function runDynamicControllerWorker(input: {
 	dynamic: CompiledDynamicWorkflowTask;
 	dynamicUi?: DynamicWorkflowUi;
 	availableModels?: WorkflowModelInfo[];
+	hostCapabilities?: WorkflowHostCapabilities;
 	stopSignal?: AbortSignal;
 }): Promise<unknown> {
 	const resolved = await resolveWorkflowHelperRef(
@@ -5433,6 +5451,7 @@ async function runDynamicControllerWorker(input: {
 	});
 	const helperCallCounts = new Map<string, number>();
 	const workflowCallCounts = new Map<string, number>();
+	const hostCallCounts = new Map<string, number>();
 	const agentOpIds = new Set<string>();
 	const replayedOpIds = new Set<string>();
 	let settled = false;
@@ -5480,6 +5499,7 @@ async function runDynamicControllerWorker(input: {
 				await handleDynamicWorkerMessage(input, message, {
 					helperCallCounts,
 					workflowCallCounts,
+					hostCallCounts,
 					agentOpIds,
 					replayedOpIds,
 					replayPrefix,
@@ -5592,12 +5612,14 @@ async function handleDynamicWorkerMessage(
 		helperSpecPath: string;
 		dynamic: CompiledDynamicWorkflowTask;
 		dynamicUi?: DynamicWorkflowUi;
+		hostCapabilities?: WorkflowHostCapabilities;
 		stopSignal?: AbortSignal;
 	},
 	message: any,
 	state: {
 		helperCallCounts: Map<string, number>;
 		workflowCallCounts: Map<string, number>;
+		hostCallCounts: Map<string, number>;
 		agentOpIds: Set<string>;
 		replayedOpIds: Set<string>;
 		replayPrefix: { opIds: string[]; cursor: number };
@@ -5794,6 +5816,27 @@ async function handleDynamicWorkerMessage(
 				isSettled: state.isSettled,
 				stopSignal: input.stopSignal,
 			});
+		} else if (message.op === "host") {
+			const alias = requiredDynamicString(
+				message.name,
+				"host operation name",
+				"ctx.host.invoke()",
+			);
+			const count = (state.hostCallCounts.get(alias) ?? 0) + 1;
+			state.hostCallCounts.set(alias, count);
+			const opId = `${input.controllerTask.specId}:host:${alias}:${String(count).padStart(3, "0")}`;
+			assertDynamicReplayPrefix(state.replayPrefix, opId);
+			state.replayedOpIds.add(opId);
+			value = await runDynamicHostOperation({
+				cwd: input.cwd,
+				run: input.run,
+				controllerTask: input.controllerTask,
+				dynamic: input.dynamic,
+				hostCapabilities: input.hostCapabilities,
+				alias,
+				callIndex: count,
+				request: message.input,
+			});
 		} else if (message.op === "workflow") {
 			const workflowId = requiredDynamicString(
 				message.name,
@@ -5928,6 +5971,8 @@ async function priorDynamicOperationOpIds(input: {
 						event.type === "result.read" ||
 						event.type === "helper.started" ||
 						event.type === "helper.completed" ||
+						event.type === "host.started" ||
+						event.type === "host.completed" ||
 						event.type === "workflow.started" ||
 						event.type === "workflow.completed"),
 			)
@@ -6320,6 +6365,7 @@ parentPort.on("message", (message) => {
   }
   const helperCallCounts = new Map();
   const workflowCallCounts = new Map();
+  const hostCallCounts = new Map();
   let decisionCallCount = 0;
   let fanoutPlanCallCount = 0;
   let stateIndexCallCount = 0;
@@ -6402,6 +6448,13 @@ parentPort.on("message", (message) => {
       const count = (workflowCallCounts.get(name) || 0) + 1;
       workflowCallCounts.set(name, count);
       return await call("workflow", { name, callIndex: count, input });
+    },
+    host: {
+      async invoke(name, input) {
+        const count = (hostCallCounts.get(name) || 0) + 1;
+        hostCallCounts.set(name, count);
+        return await call("host", { name, callIndex: count, input });
+      },
     },
     async agent(request) {
       return await call("agent", { request });

--- a/src/host-capabilities.ts
+++ b/src/host-capabilities.ts
@@ -1,0 +1,94 @@
+export interface WorkflowHostOperationContext {
+	cwd: string;
+	runId: string;
+	parentRunId: string | null;
+	controllerSpecId: string;
+	controllerTaskId: string;
+	controllerStageId: string;
+	workflow: {
+		name: string | null;
+		specPath: string;
+		bundleSpecPath: string;
+		bundleHash: string;
+	};
+	operation: {
+		alias: string;
+		capability: string;
+		callIndex: number;
+		opId: string;
+		requestHash: string;
+		idempotencyKey: string;
+	};
+}
+
+export interface WorkflowHostOperationAdapter {
+	invoke(
+		request: unknown,
+		context: Readonly<WorkflowHostOperationContext>,
+	): unknown | Promise<unknown>;
+	reconcile(
+		request: unknown,
+		context: Readonly<WorkflowHostOperationContext>,
+	): unknown | Promise<unknown>;
+}
+
+export type WorkflowHostCapabilities = Readonly<
+	Record<string, WorkflowHostOperationAdapter>
+>;
+
+export interface WorkflowHostCapabilityLaunchContext {
+	cwd: string;
+	workflow: string;
+	task?: string;
+}
+
+export type WorkflowHostCapabilityProvider = (
+	context: Readonly<WorkflowHostCapabilityLaunchContext>,
+) => WorkflowHostCapabilities | Promise<WorkflowHostCapabilities>;
+
+const providers = new Set<WorkflowHostCapabilityProvider>();
+
+export function registerWorkflowHostCapabilityProvider(
+	provider: WorkflowHostCapabilityProvider,
+): () => void {
+	providers.add(provider);
+	return () => providers.delete(provider);
+}
+
+export function clearWorkflowHostCapabilityProvidersForTests(): void {
+	providers.clear();
+}
+
+export async function resolveWorkflowHostCapabilities(
+	context: WorkflowHostCapabilityLaunchContext,
+): Promise<WorkflowHostCapabilities> {
+	const resolved: Record<string, WorkflowHostOperationAdapter> = {};
+	const frozen = deepFreeze({ ...context });
+	for (const provider of providers) {
+		const capabilities = await provider(frozen);
+		for (const [name, adapter] of Object.entries(capabilities ?? {})) {
+			if (Object.hasOwn(resolved, name)) {
+				throw new Error(`duplicate workflow host capability: ${name}`);
+			}
+			if (
+				!adapter ||
+				typeof adapter.invoke !== "function" ||
+				typeof adapter.reconcile !== "function"
+			) {
+				throw new Error(`invalid workflow host capability adapter: ${name}`);
+			}
+			resolved[name] = adapter;
+		}
+	}
+	return Object.freeze(resolved);
+}
+
+export function deepFreeze<T>(value: T): T {
+	if (value && typeof value === "object" && !Object.isFrozen(value)) {
+		for (const child of Object.values(value as Record<string, unknown>)) {
+			deepFreeze(child);
+		}
+		Object.freeze(value);
+	}
+	return value;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,18 @@ export {
 } from "./engine.js";
 export type { ResumeRunSummary, StopRunSummary } from "./engine.js";
 export {
+	clearWorkflowHostCapabilityProvidersForTests,
+	registerWorkflowHostCapabilityProvider,
+	resolveWorkflowHostCapabilities,
+} from "./host-capabilities.js";
+export type {
+	WorkflowHostCapabilities,
+	WorkflowHostCapabilityLaunchContext,
+	WorkflowHostCapabilityProvider,
+	WorkflowHostOperationAdapter,
+	WorkflowHostOperationContext,
+} from "./host-capabilities.js";
+export {
 	estimateWorkflowDurationMs,
 	findDuplicateActiveRun,
 	formatApproxDuration,

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,6 +185,10 @@ export interface DynamicWorkflowNestedSpec {
 	uses: string;
 }
 
+export interface DynamicWorkflowHostOperationSpec {
+	capability: string;
+}
+
 export interface DynamicDecisionLoopExecutionProfileSpec {
 	agent?: string;
 	model?: string;
@@ -240,6 +244,7 @@ export interface DynamicWorkflowStageSpec {
 	permissions?: DynamicWorkflowPermissionsSpec;
 	helpers?: Record<string, DynamicWorkflowHelperSpec>;
 	workflows?: Record<string, DynamicWorkflowNestedSpec>;
+	hostOperations?: Record<string, DynamicWorkflowHostOperationSpec>;
 	decisionLoop?: DynamicDecisionLoopSpec;
 }
 
@@ -507,6 +512,10 @@ export interface CompiledDynamicNestedWorkflow {
 	usesPath?: string;
 }
 
+export interface CompiledDynamicHostOperation {
+	capability: string;
+}
+
 export interface CompiledDynamicDecisionLoopExecutionProfile {
 	agent?: string;
 	model?: string;
@@ -569,6 +578,7 @@ export interface CompiledDynamicWorkflowTask {
 	};
 	helpers: Record<string, CompiledDynamicWorkflowHelper>;
 	workflows: Record<string, CompiledDynamicNestedWorkflow>;
+	hostOperations: Record<string, CompiledDynamicHostOperation>;
 	decisionLoop?: CompiledDynamicDecisionLoop;
 	runtimeOverrides?: WorkflowRuntimeDefaults;
 	availableModels?: WorkflowModelInfo[];

--- a/test/unit/dynamic-host-operations.test.mjs
+++ b/test/unit/dynamic-host-operations.test.mjs
@@ -157,16 +157,23 @@ test("completed host operation replays without invoking the adapter twice", asyn
 		const completed = await finishedRun(cwd, specPath, hostCapabilities);
 		assert.equal(invokes, 1);
 
-		const run = await readRunRecord(cwd, completed.runId);
-		const task = run.tasks.find((candidate) => candidate.stageId === "host");
-		task.status = "failed";
-		task.statusDetail = "test_replay";
-		task.completedAt = new Date().toISOString();
-		run.status = "failed";
-		await writeRunRecord(cwd, run);
-		const resumed = await resumeRun(cwd, run.runId, { hostCapabilities });
-		await waitForRun(cwd, resumed.run.runId, 10_000, { hostCapabilities });
-		assert.equal(invokes, 1);
+		const unregister = registerWorkflowHostCapabilityProvider(() =>
+			hostCapabilities,
+		);
+		try {
+			const run = await readRunRecord(cwd, completed.runId);
+			const task = run.tasks.find((candidate) => candidate.stageId === "host");
+			task.status = "failed";
+			task.statusDetail = "test_replay";
+			task.completedAt = new Date().toISOString();
+			run.status = "failed";
+			await writeRunRecord(cwd, run);
+			const resumed = await resumeRun(cwd, run.runId);
+			await waitForRun(cwd, resumed.run.runId, 10_000);
+			assert.equal(invokes, 1);
+		} finally {
+			unregister();
+		}
 	} finally {
 		rmSync(cwd, { recursive: true, force: true });
 	}
@@ -217,12 +224,22 @@ test("dangling started operation reconciles with the original idempotency key", 
 				},
 			},
 		};
-		const resumed = await resumeRun(cwd, run.runId, { hostCapabilities });
-		const finished = await waitForRun(cwd, resumed.run.runId, 10_000, { hostCapabilities });
-		assert.equal(finished.status, "completed", JSON.stringify(finished.tasks));
-		assert.equal(invokes, 0);
-		assert.equal(reconciliations.length, 1);
-		assert.equal(reconciliations[0].context.operation.idempotencyKey, idempotencyKey);
+		const unregister = registerWorkflowHostCapabilityProvider(() =>
+			hostCapabilities,
+		);
+		try {
+			const resumed = await resumeRun(cwd, run.runId);
+			const finished = await waitForRun(cwd, resumed.run.runId, 10_000);
+			assert.equal(finished.status, "completed", JSON.stringify(finished.tasks));
+			assert.equal(invokes, 0);
+			assert.equal(reconciliations.length, 1);
+			assert.equal(
+				reconciliations[0].context.operation.idempotencyKey,
+				idempotencyKey,
+			);
+		} finally {
+			unregister();
+		}
 	} finally {
 		rmSync(cwd, { recursive: true, force: true });
 	}
@@ -280,5 +297,25 @@ test("host capability providers receive frozen launch context and reject collisi
 	} finally {
 		unregister();
 		clearWorkflowHostCapabilityProvidersForTests();
+	}
+});
+
+test("host operation rejects non-JSON adapter results", async () => {
+	const cwd = project();
+	try {
+		const run = await finishedRun(cwd, writeHostWorkflow(cwd), {
+			"test.echo.v1": {
+				invoke() {
+					return { invalid: undefined };
+				},
+				reconcile() {
+					throw new Error("unexpected reconcile");
+				},
+			},
+		});
+		assert.equal(run.status, "failed");
+		assert.match(String(run.tasks[0].lastMessage), /only JSON values/iu);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
 	}
 });

--- a/test/unit/dynamic-host-operations.test.mjs
+++ b/test/unit/dynamic-host-operations.test.mjs
@@ -169,7 +169,12 @@ test("completed host operation replays without invoking the adapter twice", asyn
 			run.status = "failed";
 			await writeRunRecord(cwd, run);
 			const resumed = await resumeRun(cwd, run.runId);
-			await waitForRun(cwd, resumed.run.runId, 10_000);
+			const finished = await waitForRun(cwd, resumed.run.runId, 10_000);
+			assert.equal(
+				finished.status,
+				"completed",
+				JSON.stringify(finished.tasks),
+			);
 			assert.equal(invokes, 1);
 		} finally {
 			unregister();

--- a/test/unit/dynamic-host-operations.test.mjs
+++ b/test/unit/dynamic-host-operations.test.mjs
@@ -1,0 +1,284 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+	resumeRun,
+	runWorkflowSpec,
+	waitForRun,
+} from "../../.tmp/unit/engine.js";
+import { readArtifactGraphControl } from "../../.tmp/unit/artifact-graph-runtime.js";
+import {
+	appendDynamicEvent,
+	hashDynamicRequest,
+	readDynamicEvents,
+} from "../../.tmp/unit/dynamic-events.js";
+import { readRunRecord, writeRunRecord } from "../../.tmp/unit/store.js";
+import {
+	clearWorkflowHostCapabilityProvidersForTests,
+	registerWorkflowHostCapabilityProvider,
+	resolveWorkflowHostCapabilities,
+} from "../../.tmp/unit/host-capabilities.js";
+
+function project() {
+	return mkdtempSync(join(tmpdir(), "pi-workflow-host-operation-"));
+}
+
+function writeHostWorkflow(cwd, controllerSource = null, hostOperations = {
+	echo: { capability: "test.echo.v1" },
+}) {
+	const root = join(cwd, "workflows", "host-operation");
+	mkdirSync(join(root, "helpers"), { recursive: true });
+	writeFileSync(
+		join(root, "helpers", "controller.mjs"),
+		controllerSource ?? [
+			"export default async function controller(ctx) {",
+			"  const value = await ctx.host.invoke('echo', { message: 'hello' });",
+			"  return {",
+			"    control: { schema: 'host-operation-result-v1', status: 'done', value },",
+			"    analysis: 'host operation completed',",
+			"    refs: [],",
+			"  };",
+			"}",
+		].join("\n"),
+	);
+	const specPath = join(root, "spec.json");
+	writeFileSync(specPath, JSON.stringify({
+		schemaVersion: 1,
+		name: "host-operation",
+		artifactGraph: {
+			stages: [{
+				id: "host",
+				type: "dynamic",
+				dynamic: {
+					uses: "./helpers/controller.mjs",
+					permissions: { approval: "auto" },
+					hostOperations,
+				},
+			}],
+		},
+	}));
+	return specPath;
+}
+
+async function finishedRun(cwd, specPath, hostCapabilities) {
+	const run = await runWorkflowSpec(specPath, cwd, {
+		task: "invoke the declared host operation",
+		hostCapabilities,
+	});
+	return waitForRun(cwd, run.runId, 10_000, { hostCapabilities });
+}
+
+test("declared host operation invokes the parent adapter with frozen run provenance", async () => {
+	const cwd = project();
+	const calls = [];
+	try {
+		const specPath = writeHostWorkflow(cwd);
+		const hostCapabilities = {
+			"test.echo.v1": {
+				async invoke(request, context) {
+					calls.push({ request, context });
+					assert.equal(Object.isFrozen(context), true);
+					assert.equal(Object.isFrozen(context.workflow), true);
+					assert.equal(Object.isFrozen(context.operation), true);
+					return { echoed: request.message };
+				},
+				async reconcile() {
+					throw new Error("reconcile must not run on the first invocation");
+				},
+			},
+		};
+		const run = await finishedRun(cwd, specPath, hostCapabilities);
+
+		assert.equal(run.status, "completed", JSON.stringify(run.tasks));
+		assert.equal(calls.length, 1);
+		assert.deepEqual(calls[0].request, { message: "hello" });
+		assert.equal(calls[0].context.runId, run.runId);
+		assert.equal(calls[0].context.parentRunId, null);
+		assert.equal(calls[0].context.controllerStageId, "host");
+		assert.equal(calls[0].context.operation.alias, "echo");
+		assert.equal(calls[0].context.operation.capability, "test.echo.v1");
+		assert.match(calls[0].context.operation.idempotencyKey, /^[a-f0-9]{64}$/u);
+		assert.match(calls[0].context.workflow.bundleHash, /^[a-f0-9]{64}$/u);
+
+		const task = run.tasks.find((candidate) => candidate.stageId === "host");
+		const control = await readArtifactGraphControl(cwd, task);
+		assert.deepEqual(control.value, { echoed: "hello" });
+		const events = await readDynamicEvents(cwd, run.runId);
+		assert.deepEqual(
+			events.filter((event) => event.opId.includes(":host:echo:")).map((event) => event.type),
+			["host.started", "host.completed"],
+		);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("missing and undeclared host capabilities fail closed before invocation", async () => {
+	const cwd = project();
+	let calls = 0;
+	try {
+		const missingSpec = writeHostWorkflow(cwd);
+		const missing = await finishedRun(cwd, missingSpec, {});
+		assert.equal(missing.status, "failed");
+		assert.match(String(missing.tasks[0].lastMessage), /host capability.*unavailable/iu);
+
+		const undeclaredSpec = writeHostWorkflow(
+			cwd,
+			"export default async function controller(ctx) { return await ctx.host.invoke('undeclared', {}); }\n",
+		);
+		const undeclared = await finishedRun(cwd, undeclaredSpec, {
+			"test.echo.v1": {
+				invoke() { calls += 1; return {}; },
+				reconcile() { calls += 1; return {}; },
+			},
+		});
+		assert.equal(undeclared.status, "failed");
+		assert.match(String(undeclared.tasks[0].lastMessage), /not declared/iu);
+		assert.equal(calls, 0);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("completed host operation replays without invoking the adapter twice", async () => {
+	const cwd = project();
+	let invokes = 0;
+	try {
+		const specPath = writeHostWorkflow(cwd);
+		const hostCapabilities = {
+			"test.echo.v1": {
+				invoke() { invokes += 1; return { echoed: "hello" }; },
+				reconcile() { throw new Error("completed call must not reconcile"); },
+			},
+		};
+		const completed = await finishedRun(cwd, specPath, hostCapabilities);
+		assert.equal(invokes, 1);
+
+		const run = await readRunRecord(cwd, completed.runId);
+		const task = run.tasks.find((candidate) => candidate.stageId === "host");
+		task.status = "failed";
+		task.statusDetail = "test_replay";
+		task.completedAt = new Date().toISOString();
+		run.status = "failed";
+		await writeRunRecord(cwd, run);
+		const resumed = await resumeRun(cwd, run.runId, { hostCapabilities });
+		await waitForRun(cwd, resumed.run.runId, 10_000, { hostCapabilities });
+		assert.equal(invokes, 1);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("dangling started operation reconciles with the original idempotency key", async () => {
+	const cwd = project();
+	let invokes = 0;
+	const reconciliations = [];
+	try {
+		const specPath = writeHostWorkflow(cwd);
+		const run = await runWorkflowSpec(specPath, cwd, {
+			task: "invoke the declared host operation",
+			hostCapabilities: {},
+		});
+		const record = await readRunRecord(cwd, run.runId);
+		const task = record.tasks.find((candidate) => candidate.stageId === "host");
+		const request = {
+			alias: "echo",
+			capability: "test.echo.v1",
+			input: { message: "hello" },
+		};
+		const requestHash = hashDynamicRequest(request);
+		const idempotencyKey = hashDynamicRequest({
+			runId: run.runId,
+			controllerSpecId: task.specId,
+			opId: `${task.specId}:host:echo:001`,
+			requestHash,
+		});
+		await appendDynamicEvent(cwd, run.runId, {
+			controllerSpecId: task.specId,
+			type: "host.started",
+			opId: `${task.specId}:host:echo:001`,
+			requestHash,
+			payload: { alias: "echo", capability: "test.echo.v1", idempotencyKey },
+		});
+		task.status = "failed";
+		task.statusDetail = "simulated_process_exit";
+		record.status = "failed";
+		await writeRunRecord(cwd, record);
+
+		const hostCapabilities = {
+			"test.echo.v1": {
+				invoke() { invokes += 1; return {}; },
+				reconcile(requestValue, context) {
+					reconciliations.push({ requestValue, context });
+					return { echoed: requestValue.message };
+				},
+			},
+		};
+		const resumed = await resumeRun(cwd, run.runId, { hostCapabilities });
+		const finished = await waitForRun(cwd, resumed.run.runId, 10_000, { hostCapabilities });
+		assert.equal(finished.status, "completed", JSON.stringify(finished.tasks));
+		assert.equal(invokes, 0);
+		assert.equal(reconciliations.length, 1);
+		assert.equal(reconciliations[0].context.operation.idempotencyKey, idempotencyKey);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("host operation declarations reject unknown fields and reserved aliases", async () => {
+	const cwd = project();
+	try {
+		const unknown = writeHostWorkflow(cwd, null, {
+			echo: { capability: "test.echo.v1", extra: true },
+		});
+		await assert.rejects(
+			() => runWorkflowSpec(unknown, cwd, { task: "invalid declaration" }),
+			/hostOperations.*extra|unknown.*extra/iu,
+		);
+
+		const reserved = writeHostWorkflow(cwd, null, {
+			constructor: { capability: "test.echo.v1" },
+		});
+		await assert.rejects(
+			() => runWorkflowSpec(reserved, cwd, { task: "invalid declaration" }),
+			/reserved/iu,
+		);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("host capability providers receive frozen launch context and reject collisions", async () => {
+	clearWorkflowHostCapabilityProvidersForTests();
+	const adapter = { invoke() {}, reconcile() {} };
+	const unregister = registerWorkflowHostCapabilityProvider((context) => {
+		assert.equal(Object.isFrozen(context), true);
+		return { "test.echo.v1": adapter };
+	});
+	try {
+		const resolved = await resolveWorkflowHostCapabilities({
+			cwd: "/project",
+			workflow: "host-operation",
+			task: "test",
+		});
+		assert.equal(resolved["test.echo.v1"], adapter);
+		assert.equal(Object.isFrozen(resolved), true);
+		const unregisterDuplicate = registerWorkflowHostCapabilityProvider(() => ({
+			"test.echo.v1": adapter,
+		}));
+		try {
+			await assert.rejects(
+				() => resolveWorkflowHostCapabilities({ cwd: "/project", workflow: "host-operation" }),
+				/duplicate workflow host capability/iu,
+			);
+		} finally {
+			unregisterDuplicate();
+		}
+	} finally {
+		unregister();
+		clearWorkflowHostCapabilityProvidersForTests();
+	}
+});

--- a/test/unit/dynamic-host-operations.test.mjs
+++ b/test/unit/dynamic-host-operations.test.mjs
@@ -26,9 +26,12 @@ function project() {
 	return mkdtempSync(join(tmpdir(), "pi-workflow-host-operation-"));
 }
 
-function writeHostWorkflow(cwd, controllerSource = null, hostOperations = {
-	echo: { capability: "test.echo.v1" },
-}) {
+function writeHostWorkflow(
+	cwd,
+	controllerSource = null,
+	hostOperations = { echo: { capability: "test.echo.v1" } },
+	approval = "auto",
+) {
 	const root = join(cwd, "workflows", "host-operation");
 	mkdirSync(join(root, "helpers"), { recursive: true });
 	writeFileSync(
@@ -54,7 +57,7 @@ function writeHostWorkflow(cwd, controllerSource = null, hostOperations = {
 				type: "dynamic",
 				dynamic: {
 					uses: "./helpers/controller.mjs",
-					permissions: { approval: "auto" },
+					permissions: { approval },
 					hostOperations,
 				},
 			}],
@@ -320,6 +323,65 @@ test("host operation rejects non-JSON adapter results", async () => {
 		});
 		assert.equal(run.status, "failed");
 		assert.match(String(run.tasks[0].lastMessage), /only JSON values/iu);
+	} finally {
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("manual approval displays and binds declared host capabilities", async () => {
+	const cwd = project();
+	const prompts = [];
+	try {
+		const specPath = writeHostWorkflow(
+			cwd,
+			null,
+			{
+				zeta: { capability: "test.zeta.v1" },
+				echo: { capability: "test.echo.v1" },
+			},
+			"ask",
+		);
+		const started = await runWorkflowSpec(specPath, cwd, {
+			task: "approve governed host operation",
+			dynamicUi: {
+				hasUI: true,
+				confirm: async (_title, message) => {
+					prompts.push(message);
+					return true;
+				},
+			},
+			hostCapabilities: {
+				"test.echo.v1": {
+					invoke() {
+						return { echoed: "hello" };
+					},
+					reconcile() {
+						throw new Error("unexpected reconcile");
+					},
+				},
+			},
+		});
+		const run = await waitForRun(cwd, started.runId, 10_000, {
+			hostCapabilities: {
+				"test.echo.v1": {
+					invoke: () => ({ echoed: "hello" }),
+					reconcile: () => ({ echoed: "hello" }),
+				},
+			},
+		});
+		assert.equal(run.status, "completed", JSON.stringify(run.tasks));
+		assert.equal(prompts.length, 1);
+		assert.match(
+			prompts[0],
+			/Declared host operations: echo -> test\.echo\.v1, zeta -> test\.zeta\.v1/u,
+		);
+		const approval = (await readDynamicEvents(cwd, run.runId)).find(
+			(event) => event.type === "approval.pending",
+		);
+		assert.deepEqual(approval.payload.approvalScope.hostOperations, {
+			echo: { capability: "test.echo.v1" },
+			zeta: { capability: "test.zeta.v1" },
+		});
 	} finally {
 		rmSync(cwd, { recursive: true, force: true });
 	}


### PR DESCRIPTION
## Summary
- add declarative dynamic host-operation aliases and parent-process capability providers
- keep adapters out of workerData while supplying immutable run, parent-run, and pinned bundle provenance
- persist started/completed receipts for completed replay and dangling-start reconciliation with a stable idempotency key
- fail closed for undeclared/unavailable capabilities and non-JSON requests/results
- bind sorted alias-to-capability mappings into manual approval scope and display them in the approval prompt

## Verification
- `npm run typecheck`
- `npm run check:public-surface`
- `npm run test:build >/dev/null && node --test test/unit/dynamic-host-operations.test.mjs` (8 passed)
- adjacent dynamic runtime suite: 147 passed; its one initial failure was the missing `dist` precondition, then `npm run build` plus that exact built-dist test passed 1/1
- independent exact-head Codex review: CLEAN

This change is merged in the CallTelemetry fork as calltelemetry/pi-workflow#1 at merge commit `3884618e12174f9ecea178f120d29849b16f3000`. No npm package was published.