### PR TITLE
fix: reject duplicate workflow output sections

### DIFF
--- a/src/workflow-output-artifacts.ts
+++ b/src/workflow-output-artifacts.ts
@@ -200,6 +200,30 @@ interface SectionRequirements {
 	refsMinItems: number;
 }
 
+interface SectionObservation {
+	name: WorkflowOutputSectionName;
+	start: number;
+	contentStart: number;
+	contentEnd: number;
+	end?: number;
+}
+
+interface TextRange {
+	start: number;
+	end: number;
+}
+
+interface SectionLayoutScan {
+	sections: SectionMatch[];
+	observations: SectionObservation[];
+	duplicateNames: ReadonlySet<WorkflowOutputSectionName>;
+	duplicateCounts: ReadonlyMap<WorkflowOutputSectionName, number>;
+	outsideRanges: TextRange[];
+	complete: boolean;
+	repairEligible: boolean;
+	hasExtraProtocolBlocks: boolean;
+}
+
 export function parseWorkflowOutput(
 	raw: string,
 	options: ParseWorkflowOutputOptions = {},
@@ -208,22 +232,22 @@ export function parseWorkflowOutput(
 	const issues: WorkflowOutputIssue[] = [];
 	const repairs: WorkflowOutputRepair[] = [];
 	const requirements = sectionRequirements(options);
-	const sections = collectSections(protocolRaw, requirements);
-	validateSectionLayout(protocolRaw, sections, issues, requirements);
+	const layout = scanSectionLayout(protocolRaw, requirements);
+	validateSectionLayout(layout, issues, requirements);
 
 	const control = parseControlSection(
-		sectionText(sections, SECTION_CONTROL),
+		sectionText(layout.sections, SECTION_CONTROL),
 		issues,
 		repairs,
 		options,
 	);
 	const analysis = parseAnalysisSection(
-		sectionText(sections, SECTION_ANALYSIS),
+		sectionText(layout.sections, SECTION_ANALYSIS),
 		issues,
 		requirements,
 	);
 	const refs = parseRefsSection(
-		sectionText(sections, SECTION_REFS),
+		sectionText(layout.sections, SECTION_REFS),
 		issues,
 		requirements,
 	);
@@ -245,7 +269,7 @@ export function parseWorkflowOutputForBundle(
 ): ParsedWorkflowOutput {
 	const parsed = parseWorkflowOutput(raw, options);
 	if (parsed.valid) return parsed;
-	return parseSanitizedWorkflowOutput(raw, options) ?? parsed;
+	return parseSanitizedWorkflowOutput(parsed.raw, options) ?? parsed;
 }
 
 /** Validate a candidate bundle fully in memory without writing task artifacts. */
@@ -405,55 +429,113 @@ function normalizedRefsMinItems(value: number | undefined): number {
 	return Number.isInteger(value) && value > 0 ? value : 0;
 }
 
-function collectSections(
+function scanSectionLayout(
 	raw: string,
 	requirements: SectionRequirements,
-): SectionMatch[] {
-	const sections: SectionMatch[] = [];
+): SectionLayoutScan {
+	const observations = collectSectionObservations(raw, requirements);
+	const sections = observations.flatMap((observation): SectionMatch[] => {
+		if (observation.end === undefined) return [];
+		return [
+			{
+				name: observation.name,
+				content: raw
+					.slice(observation.contentStart, observation.contentEnd)
+					.trim(),
+				start: observation.start,
+				end: observation.end,
+			},
+		];
+	});
+	const expected = requiredSectionOrder(requirements);
+	const complete =
+		sections.length === expected.length &&
+		sections.every((section, index) => section.name === expected[index]);
+	const { duplicateNames, duplicateCounts, hasExtraProtocolBlocks } =
+		scanStructuralSectionOpenings(raw, observations, requirements);
+	return {
+		sections,
+		observations,
+		duplicateNames,
+		duplicateCounts,
+		outsideRanges: collectOutsideTextRanges(raw, sections),
+		complete,
+		repairEligible:
+			!complete && duplicateNames.size === 0 && !hasExtraProtocolBlocks,
+		hasExtraProtocolBlocks,
+	};
+}
+
+function collectSectionObservations(
+	raw: string,
+	requirements: SectionRequirements,
+): SectionObservation[] {
+	const observations: SectionObservation[] = [];
 	let cursor = 0;
 	const expected = requiredSectionOrder(requirements);
 	for (const [index, name] of expected.entries()) {
 		const openTag = `<${name}>`;
 		const closeTag = `</${name}>`;
+		const nextTag = expected[index + 1]
+			? `<${expected[index + 1]}>`
+			: undefined;
 		const openStart = raw.indexOf(openTag, cursor);
 		if (openStart < 0) continue;
 		const contentStart = openStart + openTag.length;
 		const closeStart = findSectionClose(raw, {
+			name,
 			contentStart,
 			closeTag,
-			nextTag: expected[index + 1] ? `<${expected[index + 1]}>` : undefined,
+			nextTag,
 		});
-		if (closeStart < 0) continue;
-		const end = closeStart + closeTag.length;
-		sections.push({
+		if (closeStart >= 0) {
+			const end = closeStart + closeTag.length;
+			observations.push({
+				name,
+				start: openStart,
+				contentStart,
+				contentEnd: closeStart,
+				end,
+			});
+			cursor = end;
+			continue;
+		}
+		const nextOpen = nextTag ? raw.indexOf(nextTag, contentStart) : -1;
+		const contentEnd = nextOpen >= 0 ? nextOpen : raw.length;
+		observations.push({
 			name,
-			content: raw.slice(contentStart, closeStart).trim(),
 			start: openStart,
-			end,
+			contentStart,
+			contentEnd,
 		});
-		cursor = end;
+		cursor = contentEnd;
 	}
-	return sections;
+	return observations;
 }
 
 function findSectionClose(
 	raw: string,
-	options: { contentStart: number; closeTag: string; nextTag?: string },
+	options: {
+		name: WorkflowOutputSectionName;
+		contentStart: number;
+		closeTag: string;
+		nextTag?: string;
+	},
 ): number {
 	let searchFrom = options.contentStart;
 	let fallback = -1;
 	while (true) {
 		const candidate = raw.indexOf(options.closeTag, searchFrom);
 		if (candidate < 0) break;
-		fallback = candidate;
-		const after = skipWhitespace(raw, candidate + options.closeTag.length);
 		if (
-			options.closeTag === "</control>" &&
+			options.name !== SECTION_ANALYSIS &&
 			isInsideJsonString(raw.slice(options.contentStart, candidate))
 		) {
 			searchFrom = candidate + options.closeTag.length;
 			continue;
 		}
+		fallback = candidate;
+		const after = skipWhitespace(raw, candidate + options.closeTag.length);
 		if (options.nextTag) {
 			if (raw.startsWith(options.nextTag, after)) return candidate;
 		} else if (raw.slice(after).trim() === "") {
@@ -487,15 +569,154 @@ function isInsideJsonString(text: string): boolean {
 	return inString;
 }
 
-function validateSectionLayout(
+function scanStructuralSectionOpenings(
+	raw: string,
+	observations: readonly SectionObservation[],
+	requirements: SectionRequirements,
+): {
+	duplicateNames: ReadonlySet<WorkflowOutputSectionName>;
+	duplicateCounts: ReadonlyMap<WorkflowOutputSectionName, number>;
+	hasExtraProtocolBlocks: boolean;
+} {
+	const openingCounts = new Map<WorkflowOutputSectionName, number>();
+	const duplicateNames = new Set<WorkflowOutputSectionName>();
+	for (const observation of observations) {
+		openingCounts.set(
+			observation.name,
+			(openingCounts.get(observation.name) ?? 0) + 1,
+		);
+		const content = raw.slice(
+			observation.contentStart,
+			observation.contentEnd,
+		);
+		if (observation.name === SECTION_ANALYSIS) {
+			if (hasAnalysisSectionRestart(content)) {
+				duplicateNames.add(observation.name);
+			}
+			continue;
+		}
+		const nestedOpenings = countTagOutsideJsonStrings(
+			content,
+			`<${observation.name}>`,
+		);
+		if (nestedOpenings > 0) {
+			openingCounts.set(
+				observation.name,
+				(openingCounts.get(observation.name) ?? 0) + nestedOpenings,
+			);
+		}
+	}
+
+	for (const range of collectOutsideRanges(raw.length, observations)) {
+		const text = raw.slice(range.start, range.end);
+		for (const name of CANONICAL_SECTION_ORDER) {
+			const count = countTag(text, `<${name}>`);
+			if (count === 0) continue;
+			openingCounts.set(name, (openingCounts.get(name) ?? 0) + count);
+		}
+	}
+
+	let hasExtraProtocolBlocks = duplicateNames.size > 0;
+	const duplicateCounts = new Map<WorkflowOutputSectionName, number>();
+	for (const name of CANONICAL_SECTION_ORDER) {
+		const count = openingCounts.get(name) ?? 0;
+		if (count > 1) duplicateNames.add(name);
+		if (duplicateNames.has(name)) duplicateCounts.set(name, Math.max(count, 2));
+		const allowed = sectionRequired(name, requirements) ? 1 : 0;
+		if (count > allowed) hasExtraProtocolBlocks = true;
+	}
+	return { duplicateNames, duplicateCounts, hasExtraProtocolBlocks };
+}
+
+function collectOutsideRanges(
+	rawLength: number,
+	observations: readonly SectionObservation[],
+): TextRange[] {
+	const ranges: TextRange[] = [];
+	let cursor = 0;
+	for (const observation of observations) {
+		if (cursor < observation.start) {
+			ranges.push({ start: cursor, end: observation.start });
+		}
+		cursor = Math.max(cursor, observation.end ?? observation.contentEnd);
+	}
+	if (cursor < rawLength) ranges.push({ start: cursor, end: rawLength });
+	return ranges;
+}
+
+function collectOutsideTextRanges(
 	raw: string,
 	sections: readonly SectionMatch[],
+): TextRange[] {
+	const ranges: TextRange[] = [];
+	let cursor = 0;
+	for (const section of sections) {
+		if (
+			cursor < section.start &&
+			raw.slice(cursor, section.start).trim().length > 0
+		) {
+			ranges.push({ start: cursor, end: section.start });
+		}
+		cursor = section.end;
+	}
+	if (raw.slice(cursor).trim().length > 0) {
+		ranges.push({ start: cursor, end: raw.length });
+	}
+	return ranges;
+}
+
+function countTag(text: string, tag: string): number {
+	let count = 0;
+	let cursor = 0;
+	while (true) {
+		const index = text.indexOf(tag, cursor);
+		if (index < 0) return count;
+		count += 1;
+		cursor = index + tag.length;
+	}
+}
+
+function countTagOutsideJsonStrings(text: string, tag: string): number {
+	let count = 0;
+	let inString = false;
+	let escaped = false;
+	for (let index = 0; index < text.length; index += 1) {
+		const char = text[index] ?? "";
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (inString && char === "\\") {
+			escaped = true;
+			continue;
+		}
+		if (char === '"') {
+			inString = !inString;
+			continue;
+		}
+		if (!inString && text.startsWith(tag, index)) {
+			count += 1;
+			index += tag.length - 1;
+		}
+	}
+	return count;
+}
+
+function hasAnalysisSectionRestart(content: string): boolean {
+	const closeTag = `</${SECTION_ANALYSIS}>`;
+	const close = content.indexOf(closeTag);
+	if (close < 0) return false;
+	return content.indexOf(`<${SECTION_ANALYSIS}>`, close + closeTag.length) >= 0;
+}
+
+function validateSectionLayout(
+	layout: SectionLayoutScan,
 	issues: WorkflowOutputIssue[],
 	requirements: SectionRequirements,
 ): void {
-	validateSectionCounts(sections, issues, requirements);
-	validateCanonicalOrder(sections, issues, requirements);
-	validateNoOutsideText(raw, sections, issues);
+	validateSectionCounts(layout, issues, requirements);
+	validateCanonicalOrder(layout.sections, issues, requirements);
+	validateNoOutsideText(layout.outsideRanges, issues);
 }
 
 function parseSanitizedWorkflowOutput(
@@ -503,9 +724,12 @@ function parseSanitizedWorkflowOutput(
 	options: ParseWorkflowOutputOptions,
 ): ParsedWorkflowOutput | undefined {
 	const requirements = sectionRequirements(options);
-	const sections = collectSections(raw, requirements);
-	if (hasExactlyRequiredSections(sections, requirements)) {
-		const sanitized = sections
+	const layout = scanSectionLayout(raw, requirements);
+	if (layout.duplicateNames.size > 0 || layout.hasExtraProtocolBlocks) {
+		return undefined;
+	}
+	if (layout.complete) {
+		const sanitized = layout.sections
 			.map((section) => raw.slice(section.start, section.end).trim())
 			.join("\n");
 		if (sanitized !== raw.trim()) {
@@ -513,7 +737,7 @@ function parseSanitizedWorkflowOutput(
 			if (parsed.valid) return parsed;
 		}
 	}
-	const repaired = repairMissingTailSections(raw, requirements);
+	const repaired = repairMissingTailSections(raw, requirements, layout);
 	if (repaired !== undefined) {
 		const parsed = parseWorkflowOutput(repaired, options);
 		if (parsed.valid) return parsed;
@@ -524,74 +748,62 @@ function parseSanitizedWorkflowOutput(
 function repairMissingTailSections(
 	raw: string,
 	requirements: SectionRequirements,
+	layout: SectionLayoutScan,
 ): string | undefined {
-	const controlOpen = raw.indexOf("<control>");
-	if (controlOpen < 0) return undefined;
-	const controlContentStart = controlOpen + "<control>".length;
-	const controlClose = raw.indexOf("</control>", controlContentStart);
-	if (controlClose < 0) return undefined;
-	const controlContent = raw.slice(controlContentStart, controlClose).trim();
-	const afterControl = raw.slice(controlClose + "</control>".length);
-	let analysis = "";
-	let refs = "[]";
-	const analysisOpen = afterControl.indexOf("<analysis>");
+	if (!layout.repairEligible) return undefined;
+	const observations = new Map(
+		layout.observations.map((observation) => [observation.name, observation]),
+	);
+	const control = observations.get(SECTION_CONTROL);
+	if (!control || control.end === undefined) return undefined;
+	const contents = new Map<WorkflowOutputSectionName, string>();
+	contents.set(
+		SECTION_CONTROL,
+		raw.slice(control.contentStart, control.contentEnd).trim(),
+	);
 	if (requirements.analysisRequired) {
-		if (analysisOpen < 0) return undefined;
-		const analysisStart = analysisOpen + "<analysis>".length;
-		const analysisClose = afterControl.indexOf("</analysis>", analysisStart);
-		const refsOpenAfterAnalysis = afterControl.indexOf("<refs>", analysisStart);
-		const analysisEnd =
-			analysisClose >= 0
-				? analysisClose
-				: refsOpenAfterAnalysis >= 0
-					? refsOpenAfterAnalysis
-					: afterControl.length;
-		analysis = afterControl.slice(analysisStart, analysisEnd).trim();
-		if (analysis.length === 0) return undefined;
+		const analysis = observations.get(SECTION_ANALYSIS);
+		if (!analysis) return undefined;
+		const content = raw
+			.slice(analysis.contentStart, analysis.contentEnd)
+			.trim();
+		if (content.length === 0) return undefined;
+		contents.set(SECTION_ANALYSIS, content);
 	}
-	const refsSearchStart =
-		analysisOpen >= 0 ? analysisOpen + "<analysis>".length : 0;
-	const refsOpen = afterControl.indexOf("<refs>", refsSearchStart);
-	if (refsOpen >= 0) {
-		const refsStart = refsOpen + "<refs>".length;
-		const refsClose = afterControl.indexOf("</refs>", refsStart);
-		if (refsClose >= 0) refs = afterControl.slice(refsStart, refsClose).trim();
-	} else if (requirements.refsRequired) {
-		refs = "[]";
+	if (requirements.refsRequired) {
+		const refs = observations.get(SECTION_REFS);
+		contents.set(
+			SECTION_REFS,
+			refs?.end === undefined
+				? "[]"
+				: raw.slice(refs.contentStart, refs.contentEnd).trim(),
+		);
 	}
-	return [
-		"<control>",
-		controlContent,
-		"</control>",
-		"<analysis>",
-		analysis,
-		"</analysis>",
-		"<refs>",
-		refs,
-		"</refs>",
-	].join("\n");
-}
-
-function hasExactlyRequiredSections(
-	sections: readonly SectionMatch[],
-	requirements: SectionRequirements,
-): boolean {
-	const expected = requiredSectionOrder(requirements);
-	if (sections.length !== expected.length) return false;
-	return sections.every((section, index) => section.name === expected[index]);
+	return requiredSectionOrder(requirements)
+		.flatMap((name) => [
+			`<${name}>`,
+			contents.get(name) ?? "",
+			`</${name}>`,
+		])
+		.join("\n");
 }
 
 function validateSectionCounts(
-	sections: readonly SectionMatch[],
+	layout: SectionLayoutScan,
 	issues: WorkflowOutputIssue[],
 	requirements: SectionRequirements,
 ): void {
-	const counts = sectionCounts(sections);
 	for (const name of CANONICAL_SECTION_ORDER) {
 		const required = sectionRequired(name, requirements);
-		const count = counts.get(name) ?? 0;
+		const count = layout.sections.filter(
+			(section) => section.name === name,
+		).length;
 		if (required && count === 0) issues.push(missingSectionIssue(name));
-		if (count > 1) issues.push(duplicateSectionIssue(name));
+		if (layout.duplicateNames.has(name)) {
+			issues.push(
+				duplicateSectionIssue(name, layout.duplicateCounts.get(name) ?? 2),
+			);
+		}
 	}
 }
 
@@ -611,19 +823,10 @@ function validateCanonicalOrder(
 }
 
 function validateNoOutsideText(
-	raw: string,
-	sections: readonly SectionMatch[],
+	outsideRanges: readonly TextRange[],
 	issues: WorkflowOutputIssue[],
 ): void {
-	let cursor = 0;
-	for (const section of sections) {
-		if (raw.slice(cursor, section.start).trim().length > 0) {
-			issues.push(outsideTextIssue());
-			return;
-		}
-		cursor = section.end;
-	}
-	if (raw.slice(cursor).trim().length > 0) issues.push(outsideTextIssue());
+	if (outsideRanges.length > 0) issues.push(outsideTextIssue());
 }
 
 function parseControlSection(
@@ -2103,16 +2306,6 @@ function artifactIndex(files: Record<string, string>): Record<string, string> {
 	);
 }
 
-function sectionCounts(
-	sections: readonly SectionMatch[],
-): Map<WorkflowOutputSectionName, number> {
-	const counts = new Map<WorkflowOutputSectionName, number>();
-	for (const section of sections) {
-		counts.set(section.name, (counts.get(section.name) ?? 0) + 1);
-	}
-	return counts;
-}
-
 function sectionRequired(
 	name: WorkflowOutputSectionName,
 	requirements: SectionRequirements,
@@ -2142,11 +2335,12 @@ function missingSectionIssue(
 
 function duplicateSectionIssue(
 	section: WorkflowOutputSectionName,
+	count: number,
 ): WorkflowOutputIssue {
 	return {
 		code: "duplicate_section",
 		section,
-		message: `${section} section must appear exactly once`,
+		message: `${section} section must appear exactly once; found ${count}`,
 	};
 }
 

--- a/src/workflow-output-artifacts.ts
+++ b/src/workflow-output-artifacts.ts
@@ -522,26 +522,31 @@ function findSectionClose(
 		nextTag?: string;
 	},
 ): number {
-	let searchFrom = options.contentStart;
 	let fallback = -1;
-	while (true) {
-		const candidate = raw.indexOf(options.closeTag, searchFrom);
-		if (candidate < 0) break;
-		if (
-			options.name !== SECTION_ANALYSIS &&
-			isInsideJsonString(raw.slice(options.contentStart, candidate))
-		) {
-			searchFrom = candidate + options.closeTag.length;
-			continue;
+	let inJsonString = false;
+	let escaped = false;
+	for (let index = options.contentStart; index < raw.length; index += 1) {
+		if (options.name !== SECTION_ANALYSIS) {
+			const char = raw[index] ?? "";
+			if (escaped) {
+				escaped = false;
+				continue;
+			}
+			if (inJsonString && char === "\\") {
+				escaped = true;
+				continue;
+			}
+			if (char === '"') {
+				inJsonString = !inJsonString;
+				continue;
+			}
+			if (inJsonString) continue;
 		}
-		fallback = candidate;
-		const after = skipWhitespace(raw, candidate + options.closeTag.length);
-		if (options.nextTag) {
-			if (raw.startsWith(options.nextTag, after)) return candidate;
-		} else if (raw.slice(after).trim() === "") {
-			return candidate;
-		}
-		searchFrom = candidate + options.closeTag.length;
+		if (!raw.startsWith(options.closeTag, index)) continue;
+		fallback = index;
+		const after = skipWhitespace(raw, index + options.closeTag.length);
+		if (options.nextTag && raw.startsWith(options.nextTag, after)) return index;
+		index += options.closeTag.length - 1;
 	}
 	return fallback;
 }
@@ -550,23 +555,6 @@ function skipWhitespace(raw: string, index: number): number {
 	let cursor = index;
 	while (cursor < raw.length && /\s/.test(raw[cursor] ?? "")) cursor += 1;
 	return cursor;
-}
-
-function isInsideJsonString(text: string): boolean {
-	let inString = false;
-	let escaped = false;
-	for (const char of text) {
-		if (escaped) {
-			escaped = false;
-			continue;
-		}
-		if (char === "\\") {
-			escaped = true;
-			continue;
-		}
-		if (char === '"') inString = !inString;
-	}
-	return inString;
 }
 
 function scanStructuralSectionOpenings(
@@ -579,44 +567,32 @@ function scanStructuralSectionOpenings(
 	hasExtraProtocolBlocks: boolean;
 } {
 	const openingCounts = new Map<WorkflowOutputSectionName, number>();
-	const duplicateNames = new Set<WorkflowOutputSectionName>();
+	const addOpenings = (
+		counts: ReadonlyMap<WorkflowOutputSectionName, number>,
+	): void => {
+		for (const [name, count] of counts) {
+			openingCounts.set(name, (openingCounts.get(name) ?? 0) + count);
+		}
+	};
 	for (const observation of observations) {
 		openingCounts.set(
 			observation.name,
 			(openingCounts.get(observation.name) ?? 0) + 1,
 		);
-		const content = raw.slice(
-			observation.contentStart,
-			observation.contentEnd,
-		);
-		if (observation.name === SECTION_ANALYSIS) {
-			if (hasAnalysisSectionRestart(content)) {
-				duplicateNames.add(observation.name);
-			}
-			continue;
-		}
-		const nestedOpenings = countTagOutsideJsonStrings(
-			content,
-			`<${observation.name}>`,
-		);
-		if (nestedOpenings > 0) {
-			openingCounts.set(
+		addOpenings(
+			countStructuralSectionOpenings(
+				raw.slice(observation.contentStart, observation.contentEnd),
 				observation.name,
-				(openingCounts.get(observation.name) ?? 0) + nestedOpenings,
-			);
-		}
+			),
+		);
 	}
 
 	for (const range of collectOutsideRanges(raw.length, observations)) {
-		const text = raw.slice(range.start, range.end);
-		for (const name of CANONICAL_SECTION_ORDER) {
-			const count = countTag(text, `<${name}>`);
-			if (count === 0) continue;
-			openingCounts.set(name, (openingCounts.get(name) ?? 0) + count);
-		}
+		addOpenings(countStructuralSectionOpenings(raw.slice(range.start, range.end)));
 	}
 
-	let hasExtraProtocolBlocks = duplicateNames.size > 0;
+	const duplicateNames = new Set<WorkflowOutputSectionName>();
+	let hasExtraProtocolBlocks = false;
 	const duplicateCounts = new Map<WorkflowOutputSectionName, number>();
 	for (const name of CANONICAL_SECTION_ORDER) {
 		const count = openingCounts.get(name) ?? 0;
@@ -665,48 +641,200 @@ function collectOutsideTextRanges(
 	return ranges;
 }
 
-function countTag(text: string, tag: string): number {
-	let count = 0;
-	let cursor = 0;
-	while (true) {
-		const index = text.indexOf(tag, cursor);
-		if (index < 0) return count;
-		count += 1;
-		cursor = index + tag.length;
+function countStructuralSectionOpenings(
+	text: string,
+	initialSection?: WorkflowOutputSectionName,
+): ReadonlyMap<WorkflowOutputSectionName, number> {
+	const counts = new Map<WorkflowOutputSectionName, number>();
+	const analysisMarkers = analyzeAnalysisMarkers(text);
+	const selectedAnalysisContent = initialSection === SECTION_ANALYSIS;
+	const completeJsonSectionOpenings = new Set([
+		...findCompleteJsonSectionOpenings(text, SECTION_CONTROL),
+		...findCompleteJsonSectionOpenings(text, SECTION_REFS),
+	]);
+	let activeSection = initialSection;
+	let analysisDepth = activeSection === SECTION_ANALYSIS ? 1 : 0;
+	let analysisClosedLiteral = false;
+	let inJsonString = false;
+	let escaped = false;
+	const recordOpening = (opening: WorkflowOutputSectionName): void => {
+		counts.set(opening, (counts.get(opening) ?? 0) + 1);
+		activeSection = opening;
+		analysisDepth = opening === SECTION_ANALYSIS ? 1 : 0;
+		analysisClosedLiteral = false;
+		inJsonString = false;
+		escaped = false;
+	};
+
+	for (let index = 0; index < text.length; index += 1) {
+		if (activeSection === SECTION_ANALYSIS) {
+			const opening = sectionOpeningAt(text, index);
+			if (
+				opening &&
+				opening !== SECTION_ANALYSIS &&
+				analysisClosedLiteral &&
+				completeJsonSectionOpenings.has(index)
+			) {
+				recordOpening(opening);
+				index += `<${opening}>`.length - 1;
+				continue;
+			}
+
+			const openTag = `<${SECTION_ANALYSIS}>`;
+			const closeTag = `</${SECTION_ANALYSIS}>`;
+			if (opening === SECTION_ANALYSIS) {
+				const balancedLiteral =
+					selectedAnalysisContent &&
+					analysisMarkers.balancedSuffixOpenings.has(index);
+				if (analysisClosedLiteral && !balancedLiteral) {
+					recordOpening(SECTION_ANALYSIS);
+				} else {
+					analysisDepth += 1;
+				}
+				index += openTag.length - 1;
+				continue;
+			}
+			if (text.startsWith(closeTag, index)) {
+				analysisDepth = Math.max(0, analysisDepth - 1);
+				analysisClosedLiteral = true;
+				if (analysisDepth === 0 && !selectedAnalysisContent) {
+					activeSection = undefined;
+				}
+				index += closeTag.length - 1;
+			}
+			continue;
+		}
+
+		if (activeSection !== undefined) {
+			const char = text[index] ?? "";
+			if (escaped) {
+				escaped = false;
+				continue;
+			}
+			if (inJsonString && char === "\\") {
+				escaped = true;
+				continue;
+			}
+			if (char === '"') {
+				inJsonString = !inJsonString;
+				continue;
+			}
+			if (inJsonString) continue;
+			const closeTag = `</${activeSection}>`;
+			if (text.startsWith(closeTag, index)) {
+				activeSection = undefined;
+				index += closeTag.length - 1;
+				continue;
+			}
+		}
+
+		const opening = sectionOpeningAt(text, index);
+		if (!opening) continue;
+		recordOpening(opening);
+		index += `<${opening}>`.length - 1;
 	}
+	return counts;
 }
 
-function countTagOutsideJsonStrings(text: string, tag: string): number {
-	let count = 0;
-	let inString = false;
+function sectionOpeningAt(
+	text: string,
+	index: number,
+): WorkflowOutputSectionName | undefined {
+	return CANONICAL_SECTION_ORDER.find((name) =>
+		text.startsWith(`<${name}>`, index),
+	);
+}
+
+function analyzeAnalysisMarkers(text: string): {
+	balancedSuffixOpenings: ReadonlySet<number>;
+} {
+	const openTag = `<${SECTION_ANALYSIS}>`;
+	const closeTag = `</${SECTION_ANALYSIS}>`;
+	const markers: Array<{ index: number; delta: 1 | -1 }> = [];
+	for (let index = 0; index < text.length; index += 1) {
+		if (text.startsWith(openTag, index)) {
+			markers.push({ index, delta: 1 });
+			index += openTag.length - 1;
+			continue;
+		}
+		if (text.startsWith(closeTag, index)) {
+			markers.push({ index, delta: -1 });
+			index += closeTag.length - 1;
+		}
+	}
+
+	const cumulative: number[] = [];
+	let balance = 0;
+	for (const marker of markers) {
+		balance += marker.delta;
+		cumulative.push(balance);
+	}
+	const suffixMinimum: number[] = Array.from({ length: markers.length });
+	let runningMinimum = Number.POSITIVE_INFINITY;
+	for (let index = markers.length - 1; index >= 0; index -= 1) {
+		runningMinimum = Math.min(runningMinimum, cumulative[index] ?? 0);
+		suffixMinimum[index] = runningMinimum;
+	}
+
+	const balancedSuffixOpenings = new Set<number>();
+	for (let index = markers.length - 1; index >= 0; index -= 1) {
+		const marker = markers[index];
+		if (!marker || marker.delta === -1) continue;
+		const balanceBefore = index === 0 ? 0 : (cumulative[index - 1] ?? 0);
+		if (
+			balance - balanceBefore === 0 &&
+			(suffixMinimum[index] ?? Number.NEGATIVE_INFINITY) >= balanceBefore
+		) {
+			balancedSuffixOpenings.add(marker.index);
+		}
+	}
+	return { balancedSuffixOpenings };
+}
+
+function findCompleteJsonSectionOpenings(
+	text: string,
+	name: typeof SECTION_CONTROL | typeof SECTION_REFS,
+): ReadonlySet<number> {
+	const complete = new Set<number>();
+	const pending: number[] = [];
+	const openTag = `<${name}>`;
+	const closeTag = `</${name}>`;
+	let inJsonString = false;
 	let escaped = false;
 	for (let index = 0; index < text.length; index += 1) {
+		if (pending.length === 0) {
+			if (!text.startsWith(openTag, index)) continue;
+			pending.push(index);
+			inJsonString = false;
+			escaped = false;
+			index += openTag.length - 1;
+			continue;
+		}
 		const char = text[index] ?? "";
 		if (escaped) {
 			escaped = false;
 			continue;
 		}
-		if (inString && char === "\\") {
+		if (inJsonString && char === "\\") {
 			escaped = true;
 			continue;
 		}
 		if (char === '"') {
-			inString = !inString;
+			inJsonString = !inJsonString;
 			continue;
 		}
-		if (!inString && text.startsWith(tag, index)) {
-			count += 1;
-			index += tag.length - 1;
+		if (inJsonString) continue;
+		if (text.startsWith(openTag, index)) {
+			pending.push(index);
+			index += openTag.length - 1;
+			continue;
 		}
+		if (!text.startsWith(closeTag, index)) continue;
+		const opening = pending.pop();
+		if (opening !== undefined) complete.add(opening);
+		index += closeTag.length - 1;
 	}
-	return count;
-}
-
-function hasAnalysisSectionRestart(content: string): boolean {
-	const closeTag = `</${SECTION_ANALYSIS}>`;
-	const close = content.indexOf(closeTag);
-	if (close < 0) return false;
-	return content.indexOf(`<${SECTION_ANALYSIS}>`, close + closeTag.length) >= 0;
+	return complete;
 }
 
 function validateSectionLayout(

--- a/test/unit/unit-artifact-web.test.mjs
+++ b/test/unit/unit-artifact-web.test.mjs
@@ -8304,7 +8304,13 @@ function strictLayoutRequiredNames(options) {
 	];
 }
 
-function assertStrictLayoutDuplicate(raw, options, section, label) {
+function assertStrictLayoutDuplicate(
+	raw,
+	options,
+	section,
+	label,
+	expectedCount,
+) {
 	for (const [parserName, parser] of [
 		["direct", parseWorkflowOutput],
 		["bundle", parseWorkflowOutputForBundle],
@@ -8324,6 +8330,13 @@ function assertStrictLayoutDuplicate(raw, options, section, label) {
 			`${label} (${parserName}) lost duplicate evidence: ${JSON.stringify(parsed.issues)}`,
 		);
 		assert.match(duplicate.message, /exactly once; found [2-9]\d*/);
+		if (expectedCount !== undefined) {
+			assert.equal(
+				duplicate.message,
+				`${section} section must appear exactly once; found ${expectedCount}`,
+				`${label} (${parserName}) reported the wrong duplicate count`,
+			);
+		}
 	}
 }
 
@@ -8361,6 +8374,98 @@ test("workflow output parsers reject duplicate sections at every canonical bound
 				}
 			}
 		}
+	}
+
+	for (const openMarkerCount of [1, 2, 3, 1_000]) {
+		const mixedRaw = [
+			strictLayoutSection("control"),
+			strictLayoutSection(
+				"analysis",
+				`First analysis mentions literal ${"<analysis>".repeat(openMarkerCount)} text.`,
+			),
+			strictLayoutSection(
+				"control",
+				JSON.stringify({ schema: "stage-control-v1", digest: "second" }),
+			),
+			strictLayoutSection(
+				"analysis",
+				"Second analysis mentions literal </analysis> text.",
+			),
+		].join("\n");
+		for (const section of ["control", "analysis"]) {
+			assertStrictLayoutDuplicate(
+				mixedRaw,
+				{ analysisRequired: true, refsRequired: true },
+				section,
+				`mixed duplicate evidence with ${openMarkerCount} open-only markers for ${section}`,
+				2,
+			);
+		}
+	}
+
+	for (const count of [3, 4]) {
+		for (const openMarkerCount of [1, 3]) {
+			const raw = [
+				strictLayoutSection("control"),
+				...Array.from({ length: count }, (_, index) =>
+					strictLayoutSection(
+						"analysis",
+						index === 0
+							? `Analysis 1 mentions ${"<analysis>".repeat(openMarkerCount)} literal markers.`
+							: `Analysis ${index + 1}.`,
+					),
+				),
+				strictLayoutSection("refs"),
+			].join("\n");
+			assertStrictLayoutDuplicate(
+				raw,
+				{ analysisRequired: true, refsRequired: true },
+				"analysis",
+				`${count} analysis sections after ${openMarkerCount} open-only markers`,
+				count,
+			);
+		}
+	}
+
+	const extraAnalysisCases = [
+		{
+			name: "required analysis with two extras after refs",
+			options: { analysisRequired: true, refsRequired: true },
+			expectedCount: 3,
+			raw: [
+				strictLayoutSection("control"),
+				strictLayoutSection("analysis"),
+				strictLayoutSection("refs"),
+				strictLayoutSection(
+					"analysis",
+					"First extra mentions literal <analysis> text.",
+				),
+				strictLayoutSection("analysis", "Second extra."),
+			].join("\n"),
+		},
+		{
+			name: "optional analysis with two extras after refs",
+			options: { analysisRequired: false, refsRequired: true },
+			expectedCount: 2,
+			raw: [
+				strictLayoutSection("control"),
+				strictLayoutSection("refs"),
+				strictLayoutSection(
+					"analysis",
+					"First extra mentions literal <analysis> text.",
+				),
+				strictLayoutSection("analysis", "Second extra."),
+			].join("\n"),
+		},
+	];
+	for (const fixture of extraAnalysisCases) {
+		assertStrictLayoutDuplicate(
+			fixture.raw,
+			fixture.options,
+			"analysis",
+			fixture.name,
+			fixture.expectedCount,
+		);
 	}
 });
 
@@ -8418,6 +8523,32 @@ test("workflow output parsers retain duplicate evidence across missing-tail dama
 		);
 	}
 
+	const mixedUnclosedTail = [
+		control,
+		strictLayoutSection(
+			"analysis",
+			`First analysis mentions ${"<analysis>".repeat(3)} literal markers.`,
+		),
+		strictLayoutSection(
+			"control",
+			JSON.stringify({ schema: "stage-control-v1", digest: "second" }),
+		),
+		strictLayoutSection(
+			"analysis",
+			"Second analysis mentions literal </analysis> text.",
+		),
+		"<refs>[]",
+	].join("\n");
+	for (const section of ["control", "analysis"]) {
+		assertStrictLayoutDuplicate(
+			mixedUnclosedTail,
+			{ analysisRequired: true, refsRequired: true },
+			section,
+			`mixed open-only literal duplicate with unclosed refs for ${section}`,
+			2,
+		);
+	}
+
 	for (const options of [
 		{ analysisRequired: true, refsRequired: true },
 		{ analysisRequired: false, refsRequired: true },
@@ -8470,6 +8601,9 @@ test("workflow output parsers preserve literal markers and safe tail repairs", (
 		"Literal <analysis> opening marker remains data.",
 		"Literal </analysis> closing marker remains data.",
 		"Literal <analysis>balanced</analysis> marker pair remains data.",
+		"Compare <analysis>A</analysis> and <analysis>B</analysis> examples.",
+		"Compare literal </analysis> with literal <control> in prose.",
+		`Repeated open-only markers remain data: ${"<analysis>".repeat(1_000)}`,
 	];
 	for (const analysisText of markerCases) {
 		const raw = [
@@ -8493,6 +8627,26 @@ test("workflow output parsers preserve literal markers and safe tail repairs", (
 			const parsed = parser(raw);
 			assert.equal(parsed.valid, true, JSON.stringify(parsed.issues));
 		}
+	}
+
+	const repeatedJsonMarkers = [
+		strictLayoutSection(
+			"control",
+			JSON.stringify({
+				schema: "stage-control-v1",
+				digest: "repeated quoted markers",
+				note: "</control>".repeat(1_000),
+			}),
+		),
+		strictLayoutSection("analysis", "Detailed reasoning."),
+		strictLayoutSection(
+			"refs",
+			JSON.stringify([{ note: "</refs>".repeat(1_000) }]),
+		),
+	].join("\n");
+	for (const parser of [parseWorkflowOutput, parseWorkflowOutputForBundle]) {
+		const parsed = parser(repeatedJsonMarkers);
+		assert.equal(parsed.valid, true, JSON.stringify(parsed.issues));
 	}
 
 	const safeRepairs = [

--- a/test/unit/unit-artifact-web.test.mjs
+++ b/test/unit/unit-artifact-web.test.mjs
@@ -8286,6 +8286,238 @@ test("non artifact graph subagent launches do not request child sessions", async
 	}
 });
 
+const STRICT_LAYOUT_CONTENT = {
+	control: JSON.stringify({ schema: "stage-control-v1", digest: "ready" }),
+	analysis: "Detailed reasoning.",
+	refs: "[]",
+};
+
+function strictLayoutSection(name, content = STRICT_LAYOUT_CONTENT[name]) {
+	return `<${name}>${content}</${name}>`;
+}
+
+function strictLayoutRequiredNames(options) {
+	return [
+		"control",
+		...(options.analysisRequired ? ["analysis"] : []),
+		...(options.refsRequired ? ["refs"] : []),
+	];
+}
+
+function assertStrictLayoutDuplicate(raw, options, section, label) {
+	for (const [parserName, parser] of [
+		["direct", parseWorkflowOutput],
+		["bundle", parseWorkflowOutputForBundle],
+	]) {
+		const parsed = parser(raw, options);
+		assert.equal(
+			parsed.valid,
+			false,
+			`${label} (${parserName}) unexpectedly passed`,
+		);
+		const duplicate = parsed.issues.find(
+			(issue) =>
+				issue.code === "duplicate_section" && issue.section === section,
+		);
+		assert.ok(
+			duplicate,
+			`${label} (${parserName}) lost duplicate evidence: ${JSON.stringify(parsed.issues)}`,
+		);
+		assert.match(duplicate.message, /exactly once; found [2-9]\d*/);
+	}
+}
+
+test("workflow output parsers reject duplicate sections at every canonical boundary", () => {
+	const requirementCases = [
+		{ analysisRequired: true, refsRequired: true },
+		{ analysisRequired: false, refsRequired: true },
+		{ analysisRequired: true, refsRequired: false },
+		{ analysisRequired: false, refsRequired: false },
+	];
+	const separators = ["", "\n\n", "\nintervening prose\n"];
+
+	for (const options of requirementCases) {
+		const names = strictLayoutRequiredNames(options);
+		const canonical = names.map((name) => strictLayoutSection(name));
+		for (const duplicateName of ["control", "analysis", "refs"]) {
+			for (let boundary = 0; boundary <= canonical.length; boundary += 1) {
+				for (const separator of separators) {
+					const before = canonical.slice(0, boundary).join("\n");
+					const after = canonical.slice(boundary).join("\n");
+					const duplicateCount = names.includes(duplicateName) ? 1 : 2;
+					const duplicates = Array.from(
+						{ length: duplicateCount },
+						() => strictLayoutSection(duplicateName),
+					).join(separator);
+					const raw = [before, duplicates, after]
+						.filter((part) => part.length > 0)
+						.join(separator);
+					assertStrictLayoutDuplicate(
+						raw,
+						options,
+						duplicateName,
+						`${duplicateName} duplicate at boundary ${boundary} with ${JSON.stringify(separator)}`,
+					);
+				}
+			}
+		}
+	}
+});
+
+test("workflow output parsers retain duplicate evidence across missing-tail damage", () => {
+	const control = strictLayoutSection("control");
+	const analysis = strictLayoutSection("analysis");
+	const refs = strictLayoutSection("refs");
+	const cases = [
+		{
+			name: "duplicate analysis with refs omitted",
+			section: "analysis",
+			raw: [control, analysis, strictLayoutSection("analysis", "Second analysis.")].join(
+				"\n",
+			),
+		},
+		{
+			name: "duplicate control with the analysis close omitted",
+			section: "control",
+			raw: [
+				control,
+				strictLayoutSection(
+					"control",
+					JSON.stringify({ schema: "stage-control-v1", digest: "second" }),
+				),
+				"<analysis>Unclosed analysis.",
+				refs,
+			].join("\n"),
+		},
+		{
+			name: "duplicate analysis after literal open-only marker text",
+			section: "analysis",
+			raw: [
+				control,
+				strictLayoutSection(
+					"analysis",
+					"First analysis mentions <analysis> as literal text.",
+				),
+				strictLayoutSection("analysis", "Second analysis."),
+				refs,
+			].join("\n"),
+		},
+		{
+			name: "duplicate refs with the final close omitted",
+			section: "refs",
+			raw: [control, analysis, refs, "<refs>[]"].join("\n"),
+		},
+	];
+
+	for (const fixture of cases) {
+		assertStrictLayoutDuplicate(
+			fixture.raw,
+			{ analysisRequired: true, refsRequired: true },
+			fixture.section,
+			fixture.name,
+		);
+	}
+
+	for (const options of [
+		{ analysisRequired: true, refsRequired: true },
+		{ analysisRequired: false, refsRequired: true },
+		{ analysisRequired: true, refsRequired: false },
+		{ analysisRequired: false, refsRequired: false },
+	]) {
+		const requiredNames = strictLayoutRequiredNames(options);
+		const canonical = requiredNames
+			.map((name) => strictLayoutSection(name))
+			.join("\n");
+		for (const duplicateName of ["control", "analysis", "refs"]) {
+			const first = requiredNames.includes(duplicateName)
+				? ""
+				: strictLayoutSection(duplicateName);
+			const raw = [
+				canonical,
+				first,
+				`<${duplicateName}>${STRICT_LAYOUT_CONTENT[duplicateName]}`,
+			]
+				.filter((part) => part.length > 0)
+				.join("\n");
+			assertStrictLayoutDuplicate(
+				raw,
+				options,
+				duplicateName,
+				`${duplicateName} duplicate with an unclosed final block`,
+			);
+		}
+	}
+});
+
+test("workflow output parsers preserve literal markers and safe tail repairs", () => {
+	const requirementCases = [
+		{ analysisRequired: true, refsRequired: true },
+		{ analysisRequired: false, refsRequired: true },
+		{ analysisRequired: true, refsRequired: false },
+		{ analysisRequired: false, refsRequired: false },
+	];
+	for (const options of requirementCases) {
+		const raw = strictLayoutRequiredNames(options)
+			.map((name) => strictLayoutSection(name))
+			.join("\n");
+		for (const parser of [parseWorkflowOutput, parseWorkflowOutputForBundle]) {
+			const parsed = parser(raw, options);
+			assert.equal(parsed.valid, true, JSON.stringify(parsed.issues));
+		}
+	}
+
+	const markerCases = [
+		"Literal <analysis> opening marker remains data.",
+		"Literal </analysis> closing marker remains data.",
+		"Literal <analysis>balanced</analysis> marker pair remains data.",
+	];
+	for (const analysisText of markerCases) {
+		const raw = [
+			strictLayoutSection(
+				"control",
+				JSON.stringify({
+					schema: "stage-control-v1",
+					digest: "quoted markers",
+					note: "<control></control><analysis></analysis><refs></refs>",
+				}),
+			),
+			strictLayoutSection("analysis", analysisText),
+			strictLayoutSection(
+				"refs",
+				JSON.stringify([
+					{ note: "<control></control><analysis></analysis><refs></refs>" },
+				]),
+			),
+		].join("\n");
+		for (const parser of [parseWorkflowOutput, parseWorkflowOutputForBundle]) {
+			const parsed = parser(raw);
+			assert.equal(parsed.valid, true, JSON.stringify(parsed.issues));
+		}
+	}
+
+	const safeRepairs = [
+		[strictLayoutSection("control"), "<analysis>Unclosed analysis."].join(
+			"\n",
+		),
+		[strictLayoutSection("control"), strictLayoutSection("analysis")].join(
+			"\n",
+		),
+		[
+			strictLayoutSection("control"),
+			"<analysis>Analysis missing its close.",
+			strictLayoutSection("refs"),
+		].join("\n"),
+	];
+	for (const raw of safeRepairs) {
+		const parsed = parseWorkflowOutputForBundle(raw);
+		assert.equal(parsed.valid, true, JSON.stringify(parsed.issues));
+		assert.equal(
+			parsed.issues.some((issue) => issue.code === "duplicate_section"),
+			false,
+		);
+	}
+});
+
 test("workflow output parser accepts canonical control analysis refs sections", () => {
 	const raw = [
 		"<control>",

--- a/test/unit/unit-split-contract.test.mjs
+++ b/test/unit/unit-split-contract.test.mjs
@@ -15,7 +15,7 @@ const domainFiles = [
 	"unit-engine-store.test.mjs",
 ];
 
-test("unit domain split preserves the exact 527-test inventory", () => {
+test("unit domain split preserves the exact 530-test inventory", () => {
 	assert.equal(existsSync(join(unitDir, "unit.test.mjs")), false);
 	let inventory;
 	try {
@@ -26,7 +26,7 @@ test("unit domain split preserves the exact 527-test inventory", () => {
 		assert.fail(`invalid unit-test inventory JSON: ${error}`);
 	}
 	assert.equal(inventory.schema, "pi-workflow-unit-test-inventory-v1");
-	assert.equal(inventory.count, 527);
+	assert.equal(inventory.count, 530);
 
 	const actual = [];
 	const occurrences = new Map();

--- a/test/unit/unit-test-inventory.json
+++ b/test/unit/unit-test-inventory.json
@@ -522,19 +522,19 @@
 		{
 			"name": "workflow output parsers reject duplicate sections at every canonical boundary",
 			"occurrence": 1,
-			"sha256": "4ea67dc2ed47a325da4f079b74c7157212ee63dfd330985eef523b7ad35389f2",
+			"sha256": "ab46c9a330341e5f06144d47b31473f01b746c8806f3875b577d9d31c7423596",
 			"domain": "artifact-web"
 		},
 		{
 			"name": "workflow output parsers retain duplicate evidence across missing-tail damage",
 			"occurrence": 1,
-			"sha256": "fdb36baba9e3535dde400eb895ad9f27ba8048b242f09aea930c0d537f3d5fe2",
+			"sha256": "5070b0568e3e14fa6ee7beec5fbbbfe93e1fb9bb5748bfa84764847c7927e2fc",
 			"domain": "artifact-web"
 		},
 		{
 			"name": "workflow output parsers preserve literal markers and safe tail repairs",
 			"occurrence": 1,
-			"sha256": "b6bb9371558d71c081acdda6b3546a50ea2b1f7d181cc155daf27b069d136eb4",
+			"sha256": "035aa1c4a2299ed34c0df882122c051cdb12d01f2e5ebf986b5ddd06a4ab54e3",
 			"domain": "artifact-web"
 		},
 		{

--- a/test/unit/unit-test-inventory.json
+++ b/test/unit/unit-test-inventory.json
@@ -1,7 +1,7 @@
 {
 	"schema": "pi-workflow-unit-test-inventory-v1",
 	"source": "unit.test.mjs",
-	"count": 527,
+	"count": 530,
 	"tests": [
 		{
 			"name": "public schemaVersion 1 parser accepts artifact graph and rejects non-artifactGraph top-level shapes",
@@ -517,6 +517,24 @@
 			"name": "non artifact graph subagent launches do not request child sessions",
 			"occurrence": 1,
 			"sha256": "db9c3fe06285a2c82927757c61d3071403451b3016735dade9e51b0b7f27f14a",
+			"domain": "artifact-web"
+		},
+		{
+			"name": "workflow output parsers reject duplicate sections at every canonical boundary",
+			"occurrence": 1,
+			"sha256": "4ea67dc2ed47a325da4f079b74c7157212ee63dfd330985eef523b7ad35389f2",
+			"domain": "artifact-web"
+		},
+		{
+			"name": "workflow output parsers retain duplicate evidence across missing-tail damage",
+			"occurrence": 1,
+			"sha256": "fdb36baba9e3535dde400eb895ad9f27ba8048b242f09aea930c0d537f3d5fe2",
+			"domain": "artifact-web"
+		},
+		{
+			"name": "workflow output parsers preserve literal markers and safe tail repairs",
+			"occurrence": 1,
+			"sha256": "b6bb9371558d71c081acdda6b3546a50ea2b1f7d181cc155daf27b069d136eb4",
 			"domain": "artifact-web"
 		},
 		{


### PR DESCRIPTION
## Summary

- Add one shared, JSON-aware structural scanner for workflow-output sections.
- Reject duplicate `<control>`, `<analysis>`, and `<refs>` sections consistently across every parsing path.
- Preserve `duplicate_section` evidence through bundle sanitization and missing-tail recovery.
- Continue accepting tag-like literal text inside JSON strings and analysis prose.
- Prevent duplicate or ambiguous layouts from being auto-repaired into valid output.

## Problem

Workflow output structure was previously inspected independently by:

- direct output parsing
- bundle sanitization
- missing-tail recovery

Because those paths did not share the same structural view, bundle recovery could reconstruct only the selected sections and erase evidence of duplicate top-level sections.

A raw tag-occurrence count is also insufficient because it can misclassify tag-like text inside JSON strings or analysis prose as structural duplication.

## Approach

The following paths now consume one shared section-layout scan:

- `parseWorkflowOutput`
- `parseWorkflowOutputForBundle`
- sanitized bundle parsing
- missing-tail recovery

The structural scanner:

1. selects canonical sections in protocol order
2. distinguishes markers inside JSON strings from structural markers
3. records duplicate structural sections and their observed counts
4. preserves duplicate evidence across recovery paths
5. allows tail repair only when the observed layout is unambiguous

This PR does not change the public API, dependencies, package version, or workflow schema.

## Relationship to #2

This PR supersedes #2.

PR #2 correctly identified the duplicate top-level section bug and contributed the initial regression coverage. This successor preserves that intent while extending the fix across direct parsing, bundle sanitization, and missing-tail recovery.

Thanks to @eisen0419 for reporting the issue and providing the original tests.

## Validation

- [x] New focused regression tests — 3/3 passed
- [x] Original PR #2 regression tests — 6/6 passed
- [x] `npm run validate` — 826/826 passed
- [x] `npm run e2e` — 11/11 passed
- [x] `npm run check:public-surface` — 242 tracked files checked
- [x] `npm run pack:dry` — 4,803 package entries checked, 0 forbidden paths
- [x] Duplicate-boundary, optional-section, literal-marker, and missing-tail matrices passed
- [x] Live LLM canary using `openai-codex/gpt-5.6-sol`
  - canonical output was accepted by both parser paths
  - duplicate control was rejected by both parser paths
  - duplicate analysis with a literal marker and intervening prose was rejected by both parser paths
  - duplicate refs with missing-tail damage was rejected by both parser paths
  - 8/8 parser assertions passed

The live fixture batch used `max-parallel 4`; the corrected fixture used `serial 1`. No speed, cost, quality, or cross-regime comparison is claimed.

The first valid-canary prompt omitted the required `control.schema` and `control.digest` fields, and both parsers correctly rejected it. One corrected fixture was then used to verify the valid path.

## Risk and compatibility

The change is limited to workflow-output parsing and recovery.

Output that previously passed only because bundle recovery discarded duplicate-section evidence will now be rejected. This is intentional.

Regression coverage confirms that tag-like literal text inside valid JSON strings and analysis prose remains accepted.

---

This text was written by an Agent.
